### PR TITLE
code for Windows App Store do not have access to the ANSI calls used in Debug.cpp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,4 +10,5 @@ AC_ARG_ENABLE([debug],
 	[enable_debug="$withval"], [enable_debug=no])
 AM_CONDITIONAL([ENABLE_DEBUG], [test "$enable_debug" = yes])
 AC_CONFIG_FILES([Makefile libebml.pc])
+AC_CHECK_HEADERS([winapifamily.h])
 AC_OUTPUT

--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -36,6 +36,10 @@
 #ifndef LIBEBML_CONFIG_H
 #define LIBEBML_CONFIG_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #if defined(__linux__)
 #include <endian.h>
 #if __BYTE_ORDER == __LITTLE_ENDIAN
@@ -98,6 +102,13 @@
 // case the debug logging code is compiled in.
 #if (defined(DEBUG)||defined(_DEBUG)) && !defined(LIBEBML_DEBUG)
 #define LIBEBML_DEBUG
+#endif
+
+#ifdef HAVE_WINAPIFAMILY_H
+# include <winapifamily.h>
+# if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#  undef LIBEBML_DEBUG
+# endif
 #endif
 
 // For compilers that don't define __TIMESTAMP__ (e.g. gcc 2.95, gcc 3.2)


### PR DESCRIPTION
so we disable debug for these targets