### PR TITLE
Add cstdlib for free/malloc.

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -37,6 +37,7 @@
 #ifndef LIBEBML_BINARY_H
 #define LIBEBML_BINARY_H
 
+#include <cstdlib>
 #include <cstring>
 
 #include "EbmlTypes.h"


### PR DESCRIPTION
Needed when compiling with clang/libc++.