### PR TITLE
Xcode warnings fixes

### DIFF
--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -161,7 +161,6 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
 
     /*!
       \brief facility for Master elements to write only the head and force the size later
-      \warning
     */
     filepos_t WriteHead(IOCallback & output, int SizeLength, bool bWithDefault = false);
 

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -270,12 +270,12 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
   int PossibleID_Length = 0;
   binary PossibleSize[8]; // we don't support size stored in more than 64 bits
   uint32 PossibleSizeLength = 0;
-  uint64 SizeUnknown;
-  uint64 SizeFound;
+  uint64 SizeUnknown = 0;
+  uint64 SizeFound = 0;
   bool bElementFound = false;
 
   binary BitMask;
-  uint64 aElementPosition, aSizePosition;
+  uint64 aElementPosition = 0, aSizePosition = 0;
   while (!bElementFound) {
     // read ID
     aElementPosition = DataStream.getFilePointer();

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -131,8 +131,9 @@ void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
     ostringstream Msg;
     Msg<<"Failed to seek file "<<File<<" to offset "<<(unsigned long)Offset<<" in mode "<<Mode;
     throw CRTError(Msg.str());
-#endif // GCC2
+#else // GCC2
     mCurrentPosition = ftell(File);
+#endif
   } else {
     switch ( Mode ) {
       case SEEK_CUR:


### PR DESCRIPTION
These fixes are to fix/quiet warnings that are enabled by default in new Xcode projects, such as DoxyGen documentation and unreachable code. 