### PR TITLE
do not continue reading we reached the maximum allowed size with no ID

### DIFF
--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -408,6 +408,10 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
 
     } while (!bFound && MaxDataSize > ReadSize);
 
+    if (!bFound)
+        // we reached the maximum we could read without a proper ID
+        return NULL;
+
     SizeIdx = ReadIndex;
     ReadIndex -= PossibleID_Length;
 


### PR DESCRIPTION
There won't be any element to find here.
Reference: https://trac.videolan.org/vlc/ticket/17577

That should not be an issue since we always SkipData before reading things so we should skip this bogus data.