### PR TITLE
avoid comparing pointer data if there's not data inside

### DIFF
--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -100,7 +100,7 @@ filepos_t EbmlBinary::ReadData(IOCallback & input, ScopeMode ReadFully)
 
 bool EbmlBinary::operator==(const EbmlBinary & ElementToCompare) const
 {
-  return ((GetSize() == ElementToCompare.GetSize()) && !memcmp(Data, ElementToCompare.Data, GetSize()));
+  return ((GetSize() == ElementToCompare.GetSize()) && (GetSize() == 0 || !memcmp(Data, ElementToCompare.Data, GetSize())));
 }
 
 END_LIBEBML_NAMESPACE


### PR DESCRIPTION
It may point to NULL and crash.