### PR TITLE
fix GetDataStart() for elements read with an infinite size

### DIFF
--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -84,7 +84,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     }
 
     uint64 GetDataStart() const {
-      return GetElementPosition() + EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(GetSize(), GetSizeLength(), IsFiniteSize());
+      return GetElementPosition() + EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(EbmlElement::GetSize(), GetSizeLength(), IsFiniteSize());
     }
 
     /*!


### PR DESCRIPTION
Otherwise GetSize() returns an invalid size that is used to compute the size
length.