### PR TITLE
Fix export symbols when build as Windows DLL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,21 +74,28 @@ endif()
 set_target_properties(ebml PROPERTIES
   VERSION 4.0.0
   SOVERSION 4)
-target_include_directories(ebml PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_include_directories(ebml
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 if(MSVC)
   target_compile_definitions(ebml PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
+
+include(GenerateExportHeader)
+generate_export_header(ebml EXPORT_MACRO_NAME EBML_DLL_API)
+target_sources(ebml
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h
+)
+
 if(BUILD_SHARED_LIBS)
   set_target_properties(ebml
     PROPERTIES
-    DEFINE_SYMBOL "EBML_DLL_EXPORT"
     C_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN 1)
-  target_compile_definitions(ebml
-    PUBLIC EBML_DLL
-    PRIVATE EBML_DLL_EXPORT)
 endif()
 
 install(TARGETS ebml
@@ -99,6 +106,7 @@ install(TARGETS ebml
 
 install(FILES ${libebml_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
 install(FILES ${libebml_C_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml/c)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
 
 if(NOT DISABLE_PKGCONFIG)
   set(prefix ${CMAKE_INSTALL_PREFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ target_sources(ebml
 if(BUILD_SHARED_LIBS)
   set_target_properties(ebml
     PROPERTIES
-    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN 1)
 endif()
 

--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -40,6 +40,8 @@
 #include "config.h"
 #endif
 
+#include "ebml_export.h"
+
 #if defined(__linux__)
 #include <endian.h>
 #if __BYTE_ORDER == __LITTLE_ENDIAN
@@ -75,15 +77,6 @@
 // we use the Win32 file API. here we set the appropriate macros.
 #if defined(_WIN32)||defined(WIN32)
 
-# if defined(EBML_DLL)
-#  if defined(EBML_DLL_EXPORT)
-#   define EBML_DLL_API __declspec(dllexport)
-#  else // EBML_DLL_EXPORT
-#   define EBML_DLL_API __declspec(dllimport)
-#  endif // EBML_DLL_EXPORT
-# else // EBML_DLL
-#  define EBML_DLL_API
-# endif // EBML_DLL
 
 # ifdef _MSC_VER
 #  pragma warning(disable:4786)  // length of internal identifiers

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -86,62 +86,62 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define DEFINE_xxx_MASTER(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlMaster(Context_##x) {}
 
 #define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, NULL, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_xxx_CLASS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() {}
 
 #define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlUInteger(defval) {}
 
 #define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlSInteger(defval) {}
 
 #define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlString(defval) {}
 
 #define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlFloat(defval) {}
 
 #define DEFINE_xxx_CLASS_GLOBAL(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, NULL, global, NULL); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,*GetEbmlGlobal_Context)
 #define DEFINE_EBML_MASTER(x,id,idl,parent,name)           DEFINE_xxx_MASTER(x,id,idl,parent,name,*GetEbmlGlobal_Context)

--- a/ebml/EbmlVersion.h
+++ b/ebml/EbmlVersion.h
@@ -44,8 +44,8 @@ START_LIBEBML_NAMESPACE
 
 #define LIBEBML_VERSION 0x010306
 
-extern const std::string EbmlCodeVersion;
-extern const std::string EbmlCodeDate;
+extern const EBML_DLL_API std::string EbmlCodeVersion;
+extern const EBML_DLL_API std::string EbmlCodeDate;
 
 /*!
   \todo Closer relation between an element and the context it comes from (context is an element attribute ?)

--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -45,7 +45,7 @@ class EBML_DLL_API EbmlBinary;
 
 class EBML_DLL_API SafeReadIOCallback {
 public:
-  class EndOfStreamX {
+  class EBML_DLL_API EndOfStreamX {
   public:
     size_t mMissingBytes;
     EndOfStreamX(std::size_t MissingBytes);


### PR DESCRIPTION
This pull request closes #8 and closes #36.

* Generate new public header `ebml_export.h` with [GENERATE_EXPORT_HEADER](https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html) standard macro
* Export classes which Visual Studio wants to be exported when built as DLL
* Change export define as CMake wants: is was `EBML` when building shared library; now it is `EBML_STATIC_DEFINE` for static builds.