### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,10 +96,12 @@ if(BUILD_SHARED_LIBS)
     PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN 1)
+else()
+  target_compile_definitions(ebml PUBLIC EBML_STATIC_DEFINE)
 endif()
 
 install(TARGETS ebml
-  EXPORT EbmlTargets
+  EXPORT EBMLTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -119,16 +121,14 @@ if(NOT DISABLE_PKGCONFIG)
 endif()
 
 if(NOT DISABLE_CMAKE_CONFIG)
-  if(WIN32)
-    set(CMAKE_INSTALL_PACKAGEDIR cmake)
-  else()
-    set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-  endif()
+  set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/EBML)
   include(CMakePackageConfigHelpers)
-  write_basic_package_version_file(EbmlConfigVersion.cmake COMPATIBILITY SameMajorVersion)
-  install(EXPORT EbmlTargets DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
+  configure_package_config_file(EBMLConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/EBMLConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
+  write_basic_package_version_file(EBMLConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+  install(EXPORT EBMLTargets NAMESPACE EBML:: DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
   install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/EbmlConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/EbmlConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/EBMLConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/EBMLConfigVersion.cmake
       DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
 endif()

--- a/EbmlConfig.cmake
+++ b/EbmlConfig.cmake
@@ -1,1 +1,0 @@
-include(${CMAKE_CURRENT_LIST_DIR}/EbmlTargets.cmake)

--- a/EbmlConfig.cmake.in
+++ b/EbmlConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/EBMLTargets.cmake)
+
+check_required_components(EBML)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -86,62 +86,62 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define DEFINE_xxx_MASTER(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlMaster(Context_##x) {}
 
 #define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, NULL, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_xxx_CLASS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() {}
 
 #define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlUInteger(defval) {}
 
 #define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlSInteger(defval) {}
 
 #define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlString(defval) {}
 
 #define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlFloat(defval) {}
 
 #define DEFINE_xxx_CLASS_GLOBAL(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, NULL, global, NULL); \
-    EBML_DLL_API const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,*GetEbmlGlobal_Context)
 #define DEFINE_EBML_MASTER(x,id,idl,parent,name)           DEFINE_xxx_MASTER(x,id,idl,parent,name,*GetEbmlGlobal_Context)


### PR DESCRIPTION
* Adds ebml exported target to EBML:: namespace as recommended
* Set uniform `${CMAKE_PACKAGE_INSTALLDIR}` to make it simpler
* Properly set `EBML_FOUND` variable when `EBML` is searched in config mode