### PR TITLE
Declare and define EbmlElement::OverwriteData; minor bug fix

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -444,6 +444,7 @@ class EBML_DLL_API EbmlElement {
     bool ForceSize(uint64 NewSize);
 
     filepos_t OverwriteHead(IOCallback & output, bool bKeepPosition = false);
+    filepos_t OverwriteData(IOCallback & output, bool bKeepPosition = false);
 
     /*!
       \brief void the content of the element (replace by EbmlVoid)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -452,6 +452,7 @@ class EBML_DLL_API EbmlElement {
     uint64 VoidMe(IOCallback & output, bool bWithDefault = false);
 
     bool DefaultISset() const {return DefaultIsSet;}
+    void ForceNoDefault() {SetDefaultIsSet(false);}
     virtual bool IsDefaultValue() const = 0;
     bool IsFiniteSize() const {return bSizeIsFinite;}
 

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -714,6 +714,25 @@ filepos_t EbmlElement::OverwriteHead(IOCallback & output, bool bKeepPosition)
   return Result;
 }
 
+filepos_t EbmlElement::OverwriteData(IOCallback & output, bool bKeepPosition)
+{
+	if (ElementPosition == 0) {
+		return 0; // the element has not been written
+	}
+
+	uint64 HeaderSize = EbmlId(*this).GetLength() + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
+
+	filepos_t DataSize = GetSize();
+
+	uint64 CurrentPosition = output.getFilePointer();
+	output.setFilePointer(GetElementPosition() + HeaderSize);
+	filepos_t Result = RenderData(output, true, bKeepPosition);
+	output.setFilePointer(CurrentPosition);
+	assert(Result == DataSize);
+	return Result;
+}
+
+
 uint64 EbmlElement::VoidMe(IOCallback & output, bool bWithDefault)
 {
   if (ElementPosition == 0) {
@@ -721,7 +740,7 @@ uint64 EbmlElement::VoidMe(IOCallback & output, bool bWithDefault)
   }
 
   EbmlVoid Dummy;
-  return Dummy.Overwrite(*this, output, bWithDefault);
+  return Dummy.Overwrite(*this, output, true, bWithDefault);
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -716,20 +716,20 @@ filepos_t EbmlElement::OverwriteHead(IOCallback & output, bool bKeepPosition)
 
 filepos_t EbmlElement::OverwriteData(IOCallback & output, bool bKeepPosition)
 {
-	if (ElementPosition == 0) {
-		return 0; // the element has not been written
-	}
+  if (ElementPosition == 0) {
+    return 0; // the element has not been written
+  }
 
-	uint64 HeaderSize = EbmlId(*this).GetLength() + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
+  uint64 HeaderSize = EbmlId(*this).GetLength() + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
 
-	filepos_t DataSize = GetSize();
+  filepos_t DataSize = GetSize();
 
-	uint64 CurrentPosition = output.getFilePointer();
-	output.setFilePointer(GetElementPosition() + HeaderSize);
-	filepos_t Result = RenderData(output, true, bKeepPosition);
-	output.setFilePointer(CurrentPosition);
-	assert(Result == DataSize);
-	return Result;
+  uint64 CurrentPosition = output.getFilePointer();
+  output.setFilePointer(GetElementPosition() + HeaderSize);
+  filepos_t Result = RenderData(output, true, bKeepPosition);
+  output.setFilePointer(CurrentPosition);
+  assert(Result == DataSize);
+  return Result;
 }
 
 


### PR DESCRIPTION
While reading over a larger library which statically links to libebml and libmatroska I found this patch.  There are a set of similar changes to libmatroska as well (which are in need of cleanup), but this was simple and I thought it might be worthwhile to submit.