### PR TITLE
Correct the arguments which EbmlElement::VoidMe passes to EbmlVoid::Overwrite

### DIFF
--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -721,7 +721,7 @@ uint64 EbmlElement::VoidMe(IOCallback & output, bool bWithDefault)
   }
 
   EbmlVoid Dummy;
-  return Dummy.Overwrite(*this, output, bWithDefault);
+  return Dummy.Overwrite(*this, output, true, bWithDefault);
 }
 
 END_LIBEBML_NAMESPACE


### PR DESCRIPTION
This bug fix was originally part of #49 (which will not be immediately merged due to ABI breakage).  The prototype for ```EbmlVoid::Overwrite``` is:

```
uint64 Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
```

and so in the current master branch the ```bWithDefault``` argument is passed to ```Overwrite``` as ```ComeBackAfterward```.