### PR TITLE
Replace asserts with exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(libebml_PUBLIC_HEADERS
   ebml/EbmlDummy.h
   ebml/EbmlElement.h
   ebml/EbmlEndian.h
+  ebml/EbmlExceptions.h
   ebml/EbmlFloat.h
   ebml/EbmlHead.h
   ebml/EbmlId.h

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -37,8 +37,6 @@
 #ifndef LIBEBML_CRC32_H
 #define LIBEBML_CRC32_H
 
-#include <cassert>
-
 #include "EbmlTypes.h"
 #include "EbmlBinary.h"
 

--- a/ebml/EbmlExceptions.h
+++ b/ebml/EbmlExceptions.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+** libebml : parse EBML files, see http://embl.sourceforge.net/
+**
+** Defines all exception classes to be used in libebml.
+**
+** Copyright (C) 2019 Michael Mohr.  All rights reserved.
+**
+** This file is part of libebml.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public
+** License along with this library; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
+**
+** Contact license@matroska.org if any conditions of this licensing are
+** not clear to you.
+**
+**********************************************************************/
+
+#ifndef LIBEBML_EXCEPTIONS_H
+#define LIBEBML_EXCEPTIONS_H
+
+#include <exception>
+#include "ebml_export.h"
+#include "ebml/EbmlConfig.h"
+
+START_LIBEBML_NAMESPACE
+
+class EBML_DLL_API EbmlError : public std::exception
+{
+  private:
+    const char *reason;
+  public:
+    explicit EbmlError(const char *why) { this->reason = why; }
+    const char * what() const throw() override { return this->reason; }
+};
+
+END_LIBEBML_NAMESPACE
+
+#endif //LIBEBML_EXCEPTIONS_H

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -38,8 +38,6 @@
 #ifndef LIBEBML_SINTEGER_H
 #define LIBEBML_SINTEGER_H
 
-#include <cassert>
-
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -35,10 +35,8 @@
 
 #include "EbmlTypes.h"
 
-#include <cassert>
 #include <exception>
 #include <cstdio>
-// #include <iostream>
 
 
 START_LIBEBML_NAMESPACE

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -36,6 +36,7 @@
 */
 #include <string>
 
+#include "ebml/EbmlExceptions.h"
 #include "ebml/EbmlBinary.h"
 #include "ebml/StdIOCallback.h"
 
@@ -52,7 +53,8 @@ EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)
     Data = NULL;
   else {
     Data = (binary *)malloc(GetSize() * sizeof(binary));
-    assert(Data != NULL);
+    if(Data == nullptr)
+      throw EbmlError("Unable to allocate memory");
     memcpy(Data, ElementToClone.Data, GetSize());
   }
 }

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -34,7 +34,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
   \author Julien Coloos  <suiryc @ users.sf.net>
 */
-#include <cassert>
 #include <string>
 
 #include "ebml/EbmlBinary.h"

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -31,8 +31,6 @@
   \version \$Id: EbmlDate.cpp 1079 2005-03-03 13:18:14Z robux4 $
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
-#include <cassert>
-
 #include "ebml/EbmlDate.h"
 
 START_LIBEBML_NAMESPACE

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -32,7 +32,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 
-#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -34,8 +34,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 
-#include <cassert>
-
 #include "ebml/EbmlFloat.h"
 
 START_LIBEBML_NAMESPACE

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -34,7 +34,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 
-#include <cassert>
 #include <algorithm>
 
 #include "ebml/EbmlMaster.h"

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -32,7 +32,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
-#include <cassert>
 #include <limits>
 
 #include "ebml/EbmlSInteger.h"

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -33,8 +33,6 @@
   \version \$Id$
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
-#include <cassert>
-
 #include "ebml/EbmlString.h"
 
 START_LIBEBML_NAMESPACE

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -34,8 +34,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
-#include <cassert>
-
 #include "ebml/EbmlUInteger.h"
 
 START_LIBEBML_NAMESPACE

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -35,8 +35,6 @@
   \author Jory Stone       <jcsston @ toughguy.net>
 */
 
-#include <cassert>
-
 #include "ebml/EbmlUnicodeString.h"
 
 #include "lib/utf8-cpp/source/utf8/checked.h"

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -33,7 +33,6 @@
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
 
-#include <cassert>
 #include <climits>
 #if !defined(__GNUC__) || (__GNUC__ > 2)
 #include <sstream>

--- a/src/platform/win32/WinIOCallback.cpp
+++ b/src/platform/win32/WinIOCallback.cpp
@@ -34,8 +34,6 @@
   \author Cyrius           <suiryc @ users.sf.net>
 */
 
-#include <cassert>
-
 #include "WinIOCallback.h"
 
 #include "ebml/Debug.h"


### PR DESCRIPTION
WIP/RFC: this pull request is not in a mergeable state!  I want feedback from the library maintainers regarding whether it would be considered for merge if/when it is completed.

In its current state, the EBML library can operate in two modes:

1) Built in debug mode, the library will cause application crashes when an assertion is hit
2) Built in release mode, critical errors will be silently ignored, possibly leading to strange application crashes

I propose that the assertions in the library be changed to a custom exception class which can provide additional context regarding what expectations were not met.  This will with for both modes (1) and (2) above and allow application maintainers to better control how errors are handled.
