### PR TITLE
warning C4138 fix for #57

### DIFF
--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -101,7 +101,7 @@ DECLARE_EBML_BINARY(EbmlCrc32)
 };
 
 template <class T>
-inline unsigned int GetAlignment(T */* dummy */=NULL) // VC60 workaround
+inline unsigned int GetAlignment(T * /* dummy */=NULL) // VC60 workaround
 {
 #if defined(_MSC_VER) && (_MSC_VER >= 1300)
   return __alignof(T);
@@ -131,7 +131,7 @@ inline bool IsAlignedOn(const void *p, unsigned int alignment)
 }
 
 template <class T>
-inline bool IsAligned(const void *p, T */* dummy */=NULL)  // VC60 workaround
+inline bool IsAligned(const void *p, T * /* dummy */=NULL)  // VC60 workaround
 {
   return IsAlignedOn(p, GetAlignment<T>());
 }


### PR DESCRIPTION
Fixes: warning C4138: '*/' found outside of comment