### PR TITLE
CMakeLists.txt: set default visibility to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
 option(ENABLE_WIN32_IO "Build the Windows I/O helper class" OFF)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 include(GNUInstallDirs)
 
 set(libebml_SOURCES


### PR DESCRIPTION
It will hide all symbols that are not marked with the EBML_DLL_API
macro. It also reduces the size of dynamic builds from 342Ko to 309Ko.

Before this change:
$ objdump -T libebml.so | wc -l
1073

After this change:
$ objdump -T libebml.so | wc -l
733

Tested on linux for now.