### PR TITLE
Fixed overwrite in findNextID

### DIFF
--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -289,7 +289,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
       if (ReadSize == uint32(PossibleID_Length)) {
         return NULL; // no more data ?
       }
-      if (++PossibleID_Length > 4) {
+      if (++PossibleID_Length >= 4) {
         return NULL; // we don't support element IDs over class D
       }
       if (PossibleId[0] & BitMask) {


### PR DESCRIPTION
FindNextId contains an off by one bounds check on element sizes.

You can see in the diff that PossibleId is an array of four elements and when testing to see if we've reached the end if ensures that the possible id is greater than 4, the arrays size but NOT the arrays final index which is 3, as the array is zero indexed.