### PR TITLE
clang-tidy fixes

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -43,7 +43,7 @@ START_LIBEBML_NAMESPACE
 /*!
   \brief The size of the EBML-coded length
 */
-int EBML_DLL_API CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeIsFinite = true);
+int EBML_DLL_API CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeFinite = true);
 
 /*!
   \brief The coded value of the EBML-coded length

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -48,7 +48,7 @@ START_LIBEBML_NAMESPACE
 */
 class EBML_DLL_API EbmlStream {
   public:
-    EbmlStream(IOCallback & output);
+    EbmlStream(IOCallback & DataStream);
     ~EbmlStream();
 
     /*!

--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -77,7 +77,7 @@ public:
   void Read(void *Dst, size_t Count);
 
   void Skip(size_t Count);
-  void Seek(size_t Position);
+  void Seek(size_t Offset);
 
 private:
   SafeReadIOCallback(SafeReadIOCallback const &) { }

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -34,12 +34,12 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
-#include <stdio.h>
+#include <cstdio>
 
 #if defined(WIN32) || defined(_WIN32)
 #include <windows.h> // For OutputDebugString
 #else
-#include <time.h>
+#include <ctime>
 #include <sys/time.h>
 #endif // WIN32
 

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -272,10 +272,7 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
   //Now we finalize the CRC32
   crc ^= CRC32_NEGL;
 
-  if (crc == inputCRC)
-    return true;
-
-  return false;
+  return crc == inputCRC;
 }
 
 void EbmlCrc32::FillCRC32(const binary *input, uint32 length)

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -278,10 +278,10 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
   return false;
 }
 
-void EbmlCrc32::FillCRC32(const binary *s, uint32 n)
+void EbmlCrc32::FillCRC32(const binary *input, uint32 length)
 {
   ResetCRC();
-  Update(s, n);
+  Update(input, length);
   Finalize();
 
   /*uint32 crc = CRC32_NEGL;

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -79,8 +79,8 @@ bool EbmlDate::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->myDate < static_cast<const EbmlDate *>(Cmp)->myDate;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -427,7 +427,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
     // read the data size
     uint32 _SizeLength;
     PossibleSizeLength = ReadIndex;
-    while (1) {
+    while (true) {
       _SizeLength = PossibleSizeLength;
       SizeFound = ReadCodedSizeValue(&PossibleIdNSize[PossibleID_Length], _SizeLength, SizeUnknown);
       if (_SizeLength != 0) {

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -674,8 +674,8 @@ bool EbmlElement::CompareElements(const EbmlElement *A, const EbmlElement *B)
 {
   if (EbmlId(*A) == EbmlId(*B))
     return A->IsSmallerThan(B);
-  else
-    return false;
+
+  return false;
 }
 
 void EbmlElement::Read(EbmlStream & inDataStream, const EbmlSemanticContext & /* Context */, int & /* UpperEltFound */, EbmlElement * & /* FoundElt */, bool /* AllowDummyElt */, ScopeMode ReadFully)

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -150,8 +150,8 @@ bool EbmlFloat::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->Value < static_cast<const EbmlFloat *>(Cmp)->Value;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -163,8 +163,8 @@ bool EbmlSInteger::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->Value < static_cast<const EbmlSInteger *>(Cmp)->Value;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -153,8 +153,8 @@ bool EbmlUInteger::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->Value < static_cast<const EbmlUInteger *>(Cmp)->Value;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE


### PR DESCRIPTION
Contains a C++98 fix. I have no idea which standard this is meant to target.