### PR TITLE
CMakeLists.txt: set default visibility to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,10 @@ if(WIN32)
 endif()
 set_target_properties(ebml PROPERTIES
   VERSION 4.0.0
-  SOVERSION 4)
+  SOVERSION 4
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
 target_include_directories(ebml
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>


### PR DESCRIPTION
It will hide all symbols that are not marked with the EBML_DLL_API
macro. It also reduces the size of dynamic builds from 342Ko to 309Ko.

Before this change:
$ objdump -T libebml.so | wc -l
1073

After this change:
$ objdump -T libebml.so | wc -l
733

Replaces #61 

I'm not sure it changes the ABI. If so it may be turned into an option off by default.