### PR TITLE
clang-tidy fixes + c++11 changes

### DIFF
--- a/ebml/Debug.h
+++ b/ebml/Debug.h
@@ -110,7 +110,7 @@ class EBML_DLL_API ADbg
 {
 public:
   ADbg(int /* level */ = 0){}
-  virtual ~ADbg() {}
+  virtual ~ADbg() = default;
 
   inline int OutPut(int /* level */, const char * /* format */,...) const {
     return 0;

--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -78,7 +78,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
     binary *GetBuffer() const {return Data;}
 
     void CopyBuffer(const binary *Buffer, const uint32 BufferSize) {
-      if (Data != NULL)
+      if (Data != nullptr)
         free(Data);
       Data = (binary *)malloc(BufferSize * sizeof(binary));
       memcpy(Data, Buffer, BufferSize);

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -102,7 +102,7 @@ DECLARE_EBML_BINARY(EbmlCrc32)
 };
 
 template <class T>
-inline unsigned int GetAlignment(T * /* dummy */=NULL) // VC60 workaround
+inline unsigned int GetAlignment(T * /* dummy */=nullptr) // VC60 workaround
 {
 #if defined(_MSC_VER) && (_MSC_VER >= 1300)
   return __alignof(T);
@@ -132,7 +132,7 @@ inline bool IsAlignedOn(const void *p, unsigned int alignment)
 }
 
 template <class T>
-inline bool IsAligned(const void *p, T * /* dummy */=NULL)  // VC60 workaround
+inline bool IsAligned(const void *p, T * /* dummy */=nullptr)  // VC60 workaround
 {
   return IsAlignedOn(p, GetAlignment<T>());
 }

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -82,7 +82,7 @@ DECLARE_EBML_BINARY(EbmlCrc32)
     */
     uint32 GetCrc32() const {
       return m_crc_final;
-    };
+    }
 
     void ForceCrc32(uint32 NewValue) { m_crc_final = NewValue; SetValueIsSet();}
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -484,7 +484,7 @@ class EBML_DLL_API EbmlElement {
     /*!
       \brief special constructor for cloning
     */
-    EbmlElement(const EbmlElement & ElementToClone);
+    EbmlElement(const EbmlElement & ElementToClone) = default;
 
         inline uint64 GetDefaultSize() const {return DefaultSize;}
         inline void SetSize_(uint64 aSize) {Size = aSize;}

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -81,7 +81,7 @@ class EbmlElement;
 extern const EbmlSemanticContext Context_EbmlGlobal;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, NULL, global, NULL); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
@@ -96,41 +96,41 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, NULL, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_xxx_CLASS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() {}
 
 #define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlUInteger(defval) {}
 
 #define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlSInteger(defval) {}
 
 #define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlString(defval) {}
 
 #define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,global,defval) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, &Context_##parent, global, &EBML_INFO(x)); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlFloat(defval) {}
 
@@ -140,7 +140,7 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,global) \
     const EbmlId Id_##x    (id, idl); \
-    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, NULL, NULL, global, NULL); \
+    const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,*GetEbmlGlobal_Context)
@@ -187,7 +187,7 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 
 #define EBML_CONCRETE_DUMMY_CLASS(Type) \
     public: \
-        virtual const EbmlSemanticContext &Context() const {return *static_cast<EbmlSemanticContext*>(NULL);} \
+        virtual const EbmlSemanticContext &Context() const {return *static_cast<EbmlSemanticContext*>(nullptr);} \
         virtual const char *DebugName() const {return "DummyElement";} \
     virtual operator const EbmlId &(); \
         virtual EbmlElement & CreateElement() const {return Create();} \
@@ -384,11 +384,11 @@ class EBML_DLL_API EbmlElement {
     */
     EbmlElement * FindNext(IOCallback & DataStream, uint64 MaxDataSize);
 
-    EbmlElement * SkipData(EbmlStream & DataStream, const EbmlSemanticContext & Context, EbmlElement * TestReadElt = NULL, bool AllowDummyElt = false);
+    EbmlElement * SkipData(EbmlStream & DataStream, const EbmlSemanticContext & Context, EbmlElement * TestReadElt = nullptr, bool AllowDummyElt = false);
 
     /*!
       \brief Give a copy of the element, all data inside the element is copied
-      \return NULL if there is not enough memory
+      \return nullptr if there is not enough memory
     */
     virtual EbmlElement * Clone() const = 0;
 
@@ -469,7 +469,7 @@ class EBML_DLL_API EbmlElement {
   protected:
     /*!
       \brief find any element in the stream
-      \return a DummyRawElement if the element is unknown or NULL if the element dummy is not allowed
+      \return a DummyRawElement if the element is unknown or nullptr if the element dummy is not allowed
     */
     static EbmlElement *CreateElementUsingContext(const EbmlId & aID, const EbmlSemanticContext & Context, int & LowLevel, bool IsGlobalContext, bool bAllowDummy = false, unsigned int MaxLowerLevel = 1);
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -43,7 +43,7 @@ START_LIBEBML_NAMESPACE
 /*!
   \brief The size of the EBML-coded length
 */
-int EBML_DLL_API CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeIsFinite = true);
+int EBML_DLL_API CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeFinite = true);
 
 /*!
   \brief The coded value of the EBML-coded length

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -58,7 +58,7 @@ enum endianess {
 template<class TYPE, endianess ENDIAN> class Endian
 {
     public:
-      Endian() {}
+      Endian() = default;
 
       Endian(const TYPE value)
       {

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -54,7 +54,7 @@ class EBML_DLL_API EbmlFloat : public EbmlElement {
 
     EbmlFloat(const Precision prec = FLOAT_32);
     EbmlFloat(const double DefaultValue, const Precision prec = FLOAT_32);
-    EbmlFloat(const EbmlFloat & ElementToClone);
+    EbmlFloat(const EbmlFloat & ElementToClone) = default;
 
     virtual bool ValidateSize() const
     {

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -55,7 +55,7 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
   public:
     EbmlSInteger();
     EbmlSInteger(int64 DefaultValue);
-    EbmlSInteger(const EbmlSInteger & ElementToClone);
+    EbmlSInteger(const EbmlSInteger & ElementToClone) = default;
 
     EbmlSInteger & operator = (int64 NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
 

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -49,7 +49,7 @@ START_LIBEBML_NAMESPACE
 class EBML_DLL_API EbmlStream {
   public:
     EbmlStream(IOCallback & DataStream);
-    ~EbmlStream();
+    ~EbmlStream() = default;
 
     /*!
       \brief Find a possible next ID in the data stream

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -48,7 +48,7 @@ START_LIBEBML_NAMESPACE
 */
 class EBML_DLL_API EbmlStream {
   public:
-    EbmlStream(IOCallback & output);
+    EbmlStream(IOCallback & DataStream);
     ~EbmlStream();
 
     /*!

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -51,9 +51,9 @@ class EBML_DLL_API EbmlString : public EbmlElement {
   public:
     EbmlString();
     EbmlString(const std::string & aDefaultValue);
-    EbmlString(const EbmlString & ElementToClone);
+    EbmlString(const EbmlString & ElementToClone) = default;
 
-    virtual ~EbmlString() {}
+    virtual ~EbmlString() = default;
 
     virtual bool ValidateSize() const {return IsFiniteSize() && GetSize() < 0x7FFFFFFF;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false);

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -53,7 +53,7 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
   public:
     EbmlUInteger();
     EbmlUInteger(uint64 DefaultValue);
-    EbmlUInteger(const EbmlUInteger & ElementToClone);
+    EbmlUInteger(const EbmlUInteger & ElementToClone) = default;
 
     EbmlUInteger & operator=(uint64 NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
 

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -101,9 +101,9 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElement {
   public:
     EbmlUnicodeString();
     EbmlUnicodeString(const UTFstring & DefaultValue);
-    EbmlUnicodeString(const EbmlUnicodeString & ElementToClone);
+    EbmlUnicodeString(const EbmlUnicodeString & ElementToClone) = default;
 
-    virtual ~EbmlUnicodeString() {}
+    virtual ~EbmlUnicodeString() = default;
 
     virtual bool ValidateSize() const {return IsFiniteSize();} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false);

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -53,7 +53,7 @@ enum seek_mode
 class EBML_DLL_API IOCallback
 {
 public:
-  virtual ~IOCallback(){}
+  virtual ~IOCallback() = default;
 
   // The read callback works like most other read functions. You specify the
   // file, the buffer and the size and the function returns the bytes read.

--- a/ebml/MemIOCallback.h
+++ b/ebml/MemIOCallback.h
@@ -75,25 +75,25 @@ public:
 
     If an error occurs, an exception should be thrown.
   */
-  virtual uint64 getFilePointer() {return dataBufferPos;};
+  virtual uint64 getFilePointer() {return dataBufferPos;}
 
   /*!
     The close callback flushes the file buffers to disk and closes the file. When using the stdio
     library, this is equivalent to calling fclose. When the close is not successful, an exception
     should be thrown.
   */
-  void close() {};
+  void close() {}
 
-  binary *GetDataBuffer() const {return dataBuffer;};
-  uint64 GetDataBufferSize() {return dataBufferTotalSize;};
-  void SetDataBufferSize(uint64 newDataBufferSize) {dataBufferTotalSize = newDataBufferSize;};
+  binary *GetDataBuffer() const {return dataBuffer;}
+  uint64 GetDataBufferSize() {return dataBufferTotalSize;}
+  void SetDataBufferSize(uint64 newDataBufferSize) {dataBufferTotalSize = newDataBufferSize;}
   /*!
     Use this to write some data from another IOCallback
   */
   uint32 write(IOCallback & IOToRead, size_t Size);
 
-  bool IsOk() { return mOk; };
-  const std::string &GetLastErrorStr() { return mLastErrorStr; };
+  bool IsOk() { return mOk; }
+  const std::string &GetLastErrorStr() { return mLastErrorStr; }
 protected:
   bool mOk;
   std::string mLastErrorStr;

--- a/ebml/MemReadIOCallback.h
+++ b/ebml/MemReadIOCallback.h
@@ -47,7 +47,7 @@ public:
   MemReadIOCallback(void const *Ptr, size_t Size);
   MemReadIOCallback(EbmlBinary const &Binary);
   MemReadIOCallback(MemReadIOCallback const &Mem);
-  virtual ~MemReadIOCallback();
+  virtual ~MemReadIOCallback() = default;
 
   uint32 read(void *Buffer, size_t Size);
   void setFilePointer(int64 Offset, seek_mode Mode = seek_beginning);

--- a/ebml/StdIOCallback.h
+++ b/ebml/StdIOCallback.h
@@ -58,7 +58,7 @@ public:
   CRTError(int Error,const std::string&Description);
   CRTError(const std::string&Description,int Error=errno);
 
-  int getError()const throw(){return Error;}
+  int getError() const noexcept { return Error; }
 };
 
 // This class is currently private to the library, so there's no MATROSKA_EXPORT.
@@ -71,7 +71,7 @@ class EBML_DLL_API StdIOCallback:public IOCallback
     public:
 //  StdIOCallback(const char*Path,const char*Mode);
   StdIOCallback(const char*Path, const open_mode Mode);
-  virtual ~StdIOCallback()throw();
+  virtual ~StdIOCallback() noexcept;
 
   virtual uint32 read(void*Buffer,size_t Size);
 

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -34,12 +34,12 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
-#include <stdio.h>
+#include <cstdio>
 
 #if defined(WIN32) || defined(_WIN32)
 #include <windows.h> // For OutputDebugString
 #else
-#include <time.h>
+#include <ctime>
 #include <sys/time.h>
 #endif // WIN32
 

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -43,17 +43,17 @@
 START_LIBEBML_NAMESPACE
 
 EbmlBinary::EbmlBinary()
-  :EbmlElement(0, false), Data(NULL)
+  :EbmlElement(0, false), Data(nullptr)
 {}
 
 EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)
   :EbmlElement(ElementToClone)
 {
-  if (ElementToClone.Data == NULL)
-    Data = NULL;
+  if (ElementToClone.Data == nullptr)
+    Data = nullptr;
   else {
     Data = (binary *)malloc(GetSize() * sizeof(binary));
-    assert(Data != NULL);
+    assert(Data != nullptr);
     memcpy(Data, ElementToClone.Data, GetSize());
   }
 }
@@ -83,22 +83,22 @@ uint64 EbmlBinary::UpdateSize(bool /* bWithDefault */, bool /* bForceRender */)
 
 filepos_t EbmlBinary::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (Data != NULL)
+  if (Data != nullptr)
     free(Data);
 
   if (ReadFully == SCOPE_NO_DATA) {
-    Data = NULL;
+    Data = nullptr;
     return GetSize();
   }
 
   if (!GetSize()) {
     SetValueIsSet();
-    Data = NULL;
+    Data = nullptr;
     return 0;
   }
 
   Data = (binary *)malloc(GetSize());
-  if (Data == NULL)
+  if (Data == nullptr)
     throw CRTError(std::string("Error allocating data"));
   SetValueIsSet();
   return input.read(Data, GetSize());

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -58,7 +58,7 @@ EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)
   }
 }
 
-EbmlBinary::~EbmlBinary(void) {
+EbmlBinary::~EbmlBinary() {
   if(Data)
     free(Data);
 }

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -52,7 +52,7 @@ EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)
   if (ElementToClone.Data == nullptr)
     Data = nullptr;
   else {
-    Data = (binary *)malloc(GetSize() * sizeof(binary));
+    Data = static_cast<binary *>(malloc(GetSize() * sizeof(binary)));
     assert(Data != nullptr);
     memcpy(Data, ElementToClone.Data, GetSize());
   }
@@ -97,7 +97,7 @@ filepos_t EbmlBinary::ReadData(IOCallback & input, ScopeMode ReadFully)
     return 0;
   }
 
-  Data = (binary *)malloc(GetSize());
+  Data = static_cast<binary *>(malloc(GetSize()));
   if (Data == nullptr)
     throw CRTError(std::string("Error allocating data"));
   SetValueIsSet();

--- a/src/EbmlContexts.cpp
+++ b/src/EbmlContexts.cpp
@@ -45,9 +45,9 @@ static const EbmlSemantic EbmlGlobal_ContextList[2] =
   EbmlSemantic(false, false, EBML_INFO(EbmlVoid)),    ///< EbmlVoid
 };
 
-const EbmlSemanticContext Context_EbmlGlobal = EbmlSemanticContext(0, NULL, NULL, *GetEbmlGlobal_Context, NULL);
+const EbmlSemanticContext Context_EbmlGlobal = EbmlSemanticContext(0, nullptr, nullptr, *GetEbmlGlobal_Context, nullptr);
 
-static const EbmlSemanticContext EbmlGlobal_Context = EbmlSemanticContext(countof(EbmlGlobal_ContextList), EbmlGlobal_ContextList, NULL, *GetEbmlGlobal_Context, NULL);
+static const EbmlSemanticContext EbmlGlobal_Context = EbmlSemanticContext(countof(EbmlGlobal_ContextList), EbmlGlobal_ContextList, nullptr, *GetEbmlGlobal_Context, nullptr);
 
 const EbmlSemanticContext & GetEbmlGlobal_Context()
 {

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -272,10 +272,7 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
   //Now we finalize the CRC32
   crc ^= CRC32_NEGL;
 
-  if (crc == inputCRC)
-    return true;
-
-  return false;
+  return crc == inputCRC;
 }
 
 void EbmlCrc32::FillCRC32(const binary *input, uint32 length)

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -217,7 +217,7 @@ filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bo
 
   if (Result < GetDefaultSize()) {
     // pad the rest with 0
-    binary *Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
+    auto Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
     if (Pad != NULL) {
       memset(Pad, 0x00, GetDefaultSize() - Result);
       output.writeFully(Pad, GetDefaultSize() - Result);
@@ -233,7 +233,7 @@ filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bo
 filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
-    binary *Buffer = new (std::nothrow) binary[GetSize()];
+    auto Buffer = new (std::nothrow) binary[GetSize()];
     if (Buffer == NULL) {
       // impossible to read, skip it
       input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -278,10 +278,10 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
   return false;
 }
 
-void EbmlCrc32::FillCRC32(const binary *s, uint32 n)
+void EbmlCrc32::FillCRC32(const binary *input, uint32 length)
 {
   ResetCRC();
-  Update(s, n);
+  Update(input, length);
   Finalize();
 
   /*uint32 crc = CRC32_NEGL;

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -218,7 +218,7 @@ filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bo
   if (Result < GetDefaultSize()) {
     // pad the rest with 0
     auto Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
-    if (Pad != NULL) {
+    if (Pad != nullptr) {
       memset(Pad, 0x00, GetDefaultSize() - Result);
       output.writeFully(Pad, GetDefaultSize() - Result);
 
@@ -234,7 +234,7 @@ filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
     auto Buffer = new (std::nothrow) binary[GetSize()];
-    if (Buffer == NULL) {
+    if (Buffer == nullptr) {
       // impossible to read, skip it
       input.setFilePointer(GetSize(), seek_current);
     } else {

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -257,7 +257,7 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
     crc = m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
 
   while (length >= 4) {
-    crc ^= *(const uint32 *)input;
+    crc ^= *reinterpret_cast<const uint32 *>(input);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
@@ -317,7 +317,7 @@ void EbmlCrc32::Update(const binary *input, uint32 length)
     crc = m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
 
   while (length >= 4) {
-    crc ^= *(const uint32 *)input;
+    crc ^= *reinterpret_cast<const uint32 *>(input);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -79,8 +79,8 @@ bool EbmlDate::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->myDate < static_cast<const EbmlDate *>(Cmp)->myDate;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -427,7 +427,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
     // read the data size
     uint32 _SizeLength;
     PossibleSizeLength = ReadIndex;
-    while (1) {
+    while (true) {
       _SizeLength = PossibleSizeLength;
       SizeFound = ReadCodedSizeValue(&PossibleIdNSize[PossibleID_Length], _SizeLength, SizeUnknown);
       if (_SizeLength != 0) {

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -674,8 +674,8 @@ bool EbmlElement::CompareElements(const EbmlElement *A, const EbmlElement *B)
 {
   if (EbmlId(*A) == EbmlId(*B))
     return A->IsSmallerThan(B);
-  else
-    return false;
+
+  return false;
 }
 
 void EbmlElement::Read(EbmlStream & inDataStream, const EbmlSemanticContext & /* Context */, int & /* UpperEltFound */, EbmlElement * & /* FoundElt */, bool /* AllowDummyElt */, ScopeMode ReadFully)

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -245,19 +245,6 @@ EbmlElement::EbmlElement(uint64 aDefaultSize, bool bValueSet)
   Size = DefaultSize;
 }
 
-EbmlElement::EbmlElement(const EbmlElement & ElementToClone)
-  :Size(ElementToClone.Size)
-  ,DefaultSize(ElementToClone.DefaultSize)
-  ,SizeLength(ElementToClone.SizeLength)
-  ,bSizeIsFinite(ElementToClone.bSizeIsFinite)
-  ,ElementPosition(ElementToClone.ElementPosition)
-  ,SizePosition(ElementToClone.SizePosition)
-  ,bValueIsSet(ElementToClone.bValueIsSet)
-  ,DefaultIsSet(ElementToClone.DefaultIsSet)
-  ,bLocked(ElementToClone.bLocked)
-{
-}
-
 EbmlElement::~EbmlElement()
 {
   assert(!bLocked);

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -217,7 +217,7 @@ EbmlCallbacks::EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalI
   ,DebugName(aDebugName)
   ,Context(aContext)
 {
-  assert((Create!=NULL) || !strcmp(aDebugName, "DummyElement"));
+  assert((Create!=nullptr) || !strcmp(aDebugName, "DummyElement"));
 }
 
 const EbmlSemantic & EbmlSemanticContext::GetSemantic(size_t i) const
@@ -286,7 +286,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
     BitMask = 1 << 7;
     while (PossibleID_Length < 4) {
       if (!DataStream.read(&PossibleId[PossibleID_Length], 1))
-        return NULL;            // no more data
+        return nullptr;            // no more data
 
       ++ReadSize;
       ++PossibleID_Length;
@@ -306,7 +306,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
     }
 
     if (!bElementFound)
-      return NULL;
+      return nullptr;
 
     // read the data size
     aSizePosition = DataStream.getFilePointer();
@@ -314,7 +314,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
     do {
       if (PossibleSizeLength >= 8)
         // Size is larger than 8 bytes
-        return NULL;
+        return nullptr;
 
       ReadSize += DataStream.read(&PossibleSize[PossibleSizeLength++], 1);
       _SizeLength = PossibleSizeLength;
@@ -322,7 +322,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
     } while (_SizeLength == 0);
   }
 
-  EbmlElement *Result = NULL;
+  EbmlElement *Result = nullptr;
   EbmlId PossibleID(PossibleId, PossibleID_Length);
   if (PossibleID == EBML_INFO_ID(ClassInfos)) {
     // the element is the one expected
@@ -330,8 +330,8 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
   } else {
     /// \todo find the element in the context
     Result = new (std::nothrow) EbmlDummy(PossibleID);
-    if(Result == NULL)
-      return NULL;
+    if(Result == nullptr)
+      return nullptr;
   }
 
   Result->SetSizeLength(PossibleSizeLength);
@@ -340,7 +340,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
 
   if (!Result->ValidateSize() || (SizeFound != SizeUnknown && MaxDataSize < Result->Size)) {
     delete Result;
-    return NULL;
+    return nullptr;
   }
 
   // check if the size is not all 1s
@@ -350,7 +350,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
     if (!Result->SetSizeInfinite()) {
       /// \todo the element is not allowed to be infinite
       delete Result;
-      return NULL;
+      return nullptr;
     }
   } else Result->SetSizeInfinite(false);
   Result->ElementPosition = aElementPosition;
@@ -411,7 +411,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
       if (MaxDataSize <= ReadSize)
         break;
       if (DataStream.read(&PossibleIdNSize[ReadIndex++], 1) == 0) {
-        return NULL; // no more data ?
+        return nullptr; // no more data ?
       }
       ReadSize++;
 
@@ -419,7 +419,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
 
     if (!bFound)
       // we reached the maximum we could read without a proper ID
-      return NULL;
+      return nullptr;
 
     SizeIdx = ReadIndex;
     ReadIndex -= PossibleID_Length;
@@ -443,7 +443,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
         break;
       }
       if( DataStream.read( &PossibleIdNSize[SizeIdx++], 1 ) == 0 ) {
-        return NULL; // no more data ?
+        return nullptr; // no more data ?
       }
       ReadSize++;
       PossibleSizeLength++;
@@ -454,7 +454,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
       EbmlId PossibleID(PossibleIdNSize, PossibleID_Length);
       EbmlElement * Result = CreateElementUsingContext(PossibleID, Context, UpperLevel, false, AllowDummyElt, MaxLowerLevel);
       ///< \todo continue is misplaced
-      if (Result != NULL) {
+      if (Result != nullptr) {
         if (AllowDummyElt || !Result->IsDummy()) {
           Result->SetSizeLength(_SizeLength);
 
@@ -486,7 +486,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
     UpperLevel = UpperLevel_original;
   } while ( MaxDataSize >= ReadSize );
 
-  return NULL;
+  return nullptr;
 }
 
 /*!
@@ -494,9 +494,9 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
 */
 EbmlElement * EbmlElement::SkipData(EbmlStream & DataStream, const EbmlSemanticContext & Context, EbmlElement * TestReadElt, bool AllowDummyElt)
 {
-  EbmlElement * Result = NULL;
+  EbmlElement * Result = nullptr;
   if (bSizeIsFinite) {
-    assert(TestReadElt == NULL);
+    assert(TestReadElt == nullptr);
     assert(ElementPosition < SizePosition);
     DataStream.I_O().setFilePointer(SizePosition + CodedSizeLength(Size, SizeLength, bSizeIsFinite) + Size, seek_beginning);
     //    DataStream.I_O().setFilePointer(Size, seek_current);
@@ -505,34 +505,34 @@ EbmlElement * EbmlElement::SkipData(EbmlStream & DataStream, const EbmlSemanticC
     // read elements until an upper element is found
     /////////////////////////////////////////////////
     bool bEndFound = false;
-    while (!bEndFound && Result == NULL) {
+    while (!bEndFound && Result == nullptr) {
       // read an element
       /// \todo 0xFF... and true should be configurable
       //      EbmlElement * NewElt;
-      if (TestReadElt == NULL) {
+      if (TestReadElt == nullptr) {
         int bUpperElement = 0; // trick to call FindNextID correctly
         Result = DataStream.FindNextElement(Context, bUpperElement, 0xFFFFFFFFL, AllowDummyElt);
       } else {
         Result = TestReadElt;
-        TestReadElt = NULL;
+        TestReadElt = nullptr;
       }
 
-      if (Result != NULL) {
+      if (Result != nullptr) {
         unsigned int EltIndex;
         // data known in this Master's context
         for (EltIndex = 0; EltIndex < EBML_CTX_SIZE(Context); EltIndex++) {
           if (EbmlId(*Result) == EBML_CTX_IDX_ID(Context,EltIndex)) {
             // skip the data with its own context
-            Result = Result->SkipData(DataStream, EBML_SEM_CONTEXT(EBML_CTX_IDX(Context,EltIndex)), NULL);
+            Result = Result->SkipData(DataStream, EBML_SEM_CONTEXT(EBML_CTX_IDX(Context,EltIndex)), nullptr);
             break; // let's go to the next ID
           }
         }
 
         if (EltIndex >= EBML_CTX_SIZE(Context)) {
-          if (EBML_CTX_PARENT(Context) != NULL) {
+          if (EBML_CTX_PARENT(Context) != nullptr) {
             Result = SkipData(DataStream, *EBML_CTX_PARENT(Context), Result);
           } else {
-            assert(Context.GetGlobalContext != NULL);
+            assert(Context.GetGlobalContext != nullptr);
             if (Context != Context.GetGlobalContext()) {
               Result = SkipData(DataStream, Context.GetGlobalContext(), Result);
             } else {
@@ -552,7 +552,7 @@ EbmlElement *EbmlElement::CreateElementUsingContext(const EbmlId & aID, const Eb
                                                     int & LowLevel, bool IsGlobalContext, bool bAllowDummy, unsigned int MaxLowerLevel)
 {
   unsigned int ContextIndex;
-  EbmlElement *Result = NULL;
+  EbmlElement *Result = nullptr;
 
   // elements at the current level
   for (ContextIndex = 0; ContextIndex < EBML_CTX_SIZE(Context); ContextIndex++) {
@@ -562,30 +562,30 @@ EbmlElement *EbmlElement::CreateElementUsingContext(const EbmlId & aID, const Eb
   }
 
   // global elements
-  assert(Context.GetGlobalContext != NULL); // global should always exist, at least the EBML ones
+  assert(Context.GetGlobalContext != nullptr); // global should always exist, at least the EBML ones
   const EbmlSemanticContext & tstContext = Context.GetGlobalContext();
   if (tstContext != Context) {
     LowLevel--;
     MaxLowerLevel--;
     // recursive is good, but be carefull...
     Result = CreateElementUsingContext(aID, tstContext, LowLevel, true, bAllowDummy, MaxLowerLevel);
-    if (Result != NULL) {
+    if (Result != nullptr) {
       return Result;
     }
     LowLevel++;
     MaxLowerLevel++;
   } else {
-    return NULL;
+    return nullptr;
   }
 
   // parent elements
-  if (EBML_CTX_MASTER(Context) != NULL && aID == EBML_INFO_ID(*EBML_CTX_MASTER(Context))) {
+  if (EBML_CTX_MASTER(Context) != nullptr && aID == EBML_INFO_ID(*EBML_CTX_MASTER(Context))) {
     LowLevel++; // already one level up (same as context)
     return &EBML_INFO_CREATE(*EBML_CTX_MASTER(Context));
   }
 
   // check wether it's not part of an upper context
-  if (EBML_CTX_PARENT(Context) != NULL) {
+  if (EBML_CTX_PARENT(Context) != nullptr) {
     LowLevel++;
     MaxLowerLevel++;
     return CreateElementUsingContext(aID, *EBML_CTX_PARENT(Context), LowLevel, IsGlobalContext, bAllowDummy, MaxLowerLevel);

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -127,7 +127,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
     if (GetSize() == 4) {
       big_int32 TmpRead;
       TmpRead.Eval(Buffer);
-      int32 tmpp = int32(TmpRead);
+      auto tmpp = int32(TmpRead);
       float val;
       memcpy(&val, &tmpp, 4);
       Value = static_cast<double>(val);
@@ -135,7 +135,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
     } else if (GetSize() == 8) {
       big_int64 TmpRead;
       TmpRead.Eval(Buffer);
-      int64 tmpp = int64(TmpRead);
+      auto tmpp = int64(TmpRead);
       double val;
       memcpy(&val, &tmpp, 8);
       Value = val;

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -150,8 +150,8 @@ bool EbmlFloat::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->Value < static_cast<const EbmlFloat *>(Cmp)->Value;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -53,13 +53,6 @@ EbmlFloat::EbmlFloat(const double aDefaultValue, const EbmlFloat::Precision prec
   SetPrecision(prec);
 }
 
-EbmlFloat::EbmlFloat(const EbmlFloat & ElementToClone)
-  :EbmlElement(ElementToClone)
-  ,Value(ElementToClone.Value)
-  ,DefaultValue(ElementToClone.DefaultValue)
-{
-}
-
 void EbmlFloat::SetDefaultValue(double aValue)
 {
   assert(!DefaultISset());

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -203,7 +203,7 @@ bool EbmlMaster::CheckMandatory() const
   unsigned int EltIdx;
   for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(Context); EltIdx++) {
     if (EBML_CTX_IDX(Context,EltIdx).IsMandatory()) {
-      if (FindElt(EBML_CTX_IDX_INFO(Context,EltIdx)) == NULL) {
+      if (FindElt(EBML_CTX_IDX_INFO(Context,EltIdx)) == nullptr) {
         EbmlElement *testElement = &EBML_CTX_IDX(Context,EltIdx).Create();
         bool hasDefaultValue     = testElement->DefaultISset();
         delete testElement;
@@ -250,7 +250,7 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
   unsigned int EltIdx;
   for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(Context); EltIdx++) {
     if (EBML_CTX_IDX(Context,EltIdx).IsMandatory()) {
-      if (FindElt(EBML_CTX_IDX_INFO(Context,EltIdx)) == NULL) {
+      if (FindElt(EBML_CTX_IDX_INFO(Context,EltIdx)) == nullptr) {
         std::string missingElement;
         missingElement = "Missing element \"";
         missingElement.append(EBML_INFO_NAME(EBML_CTX_IDX_INFO(Context,EltIdx)));
@@ -275,7 +275,7 @@ EbmlElement *EbmlMaster::FindElt(const EbmlCallbacks & Callbacks) const
       return tmp;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCreateIfNull)
@@ -290,17 +290,17 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCre
   if (bCreateIfNull) {
     // add the element
     EbmlElement *NewElt = &EBML_INFO_CREATE(Callbacks);
-    if (NewElt == NULL)
-      return NULL;
+    if (NewElt == nullptr)
+      return nullptr;
 
     if (!PushElement(*NewElt)) {
       delete NewElt;
-      NewElt = NULL;
+      NewElt = nullptr;
     }
     return NewElt;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
@@ -312,7 +312,7 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
       return ElementList[Index];
   }
 
-  return NULL;
+  return nullptr;
 }
 
 /*!
@@ -343,17 +343,17 @@ EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt, bool bCreateIf
   if (bCreateIfNull) {
     // add the element
     EbmlElement *NewElt = &(PastElt.CreateElement());
-    if (NewElt == NULL)
-      return NULL;
+    if (NewElt == nullptr)
+      return nullptr;
 
     if (!PushElement(*NewElt)) {
       delete NewElt;
-      NewElt = NULL;
+      NewElt = nullptr;
     }
     return NewElt;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt) const
@@ -374,19 +374,19 @@ EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt) const
     Index++;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 EbmlElement *EbmlMaster::AddNewElt(const EbmlCallbacks & Callbacks)
 {
   // add the element
   EbmlElement *NewElt = &EBML_INFO_CREATE(Callbacks);
-  if (NewElt == NULL)
-    return NULL;
+  if (NewElt == nullptr)
+    return nullptr;
 
   if (!PushElement(*NewElt)) {
     delete NewElt;
-    NewElt = NULL;
+    NewElt = nullptr;
   }
   return NewElt;
 }
@@ -427,7 +427,7 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
   {
     inDataStream.I_O().setFilePointer(GetSizePosition() + GetSizeLength(), seek_beginning);
     ElementLevelA = inDataStream.FindNextElement(sContext, UpperEltFound, MaxSizeToRead, AllowDummyElt);
-    while (ElementLevelA != NULL && UpperEltFound <= 0 && MaxSizeToRead > 0) {
+    while (ElementLevelA != nullptr && UpperEltFound <= 0 && MaxSizeToRead > 0) {
       if (IsFiniteSize() && ElementLevelA->IsFiniteSize())
         MaxSizeToRead = GetEndPosition() - ElementLevelA->GetEndPosition(); // even if it's the default value
       if (!AllowDummyElt && ElementLevelA->IsDummy()) {

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -234,7 +234,7 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
     }
 
     if (childElement->IsMaster()) {
-      auto childMaster = (EbmlMaster *)childElement;
+      auto childMaster = reinterpret_cast<EbmlMaster *>(childElement);
 
       std::vector<std::string> childMissingElements = childMaster->FindAllMissingElements();
       std::copy(childMissingElements.begin(), childMissingElements.end(), std::back_inserter(missingElements));
@@ -315,7 +315,7 @@ EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt, bool bCreateIf
   }
 
   while (Index < ElementList.size()) {
-    if ((EbmlId)PastElt == (EbmlId)(*ElementList[Index]))
+    if (EbmlId(PastElt) == EbmlId(*ElementList[Index]))
       break;
     Index++;
   }
@@ -352,7 +352,7 @@ EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt) const
   }
 
   while (Index < ElementList.size()) {
-    if ((EbmlId)PastElt == (EbmlId)(*ElementList[Index]))
+    if (EbmlId(PastElt) == EbmlId(*ElementList[Index]))
       return ElementList[Index];
     Index++;
   }
@@ -485,7 +485,7 @@ processCrc:
 
   EBML_MASTER_ITERATOR Itr, CrcItr;
   for (Itr = ElementList.begin(); Itr != ElementList.end();) {
-    if ((EbmlId)(*(*Itr)) == EBML_ID(EbmlCrc32)) {
+    if (EbmlId(*(*Itr)) == EBML_ID(EbmlCrc32)) {
       bChecksumUsed = true;
       // remove the element
       Checksum = *(static_cast<EbmlCrc32*>(*Itr));

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -227,8 +227,7 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
 
   std::vector<std::string> missingElements;
 
-  for (size_t ChildElementNo = 0; ChildElementNo < ElementList.size(); ChildElementNo++) {
-       EbmlElement *childElement = ElementList[ChildElementNo];
+  for (auto childElement : ElementList) {
     if (!childElement->ValueIsSet()) {
       std::string missingValue;
       missingValue = "The Child Element \"";
@@ -243,8 +242,8 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
       auto childMaster = (EbmlMaster *)childElement;
 
       std::vector<std::string> childMissingElements = childMaster->FindAllMissingElements();
-      for (size_t s = 0; s < childMissingElements.size(); s++)
-        missingElements.push_back(childMissingElements[s]);
+      for (auto & childMissingElement : childMissingElements)
+        missingElements.push_back(childMissingElement);
     }
   }
   unsigned int EltIdx;
@@ -553,8 +552,8 @@ bool EbmlMaster::VerifyChecksum() const
   /// \todo remove the Checksum if it's in the list
   /// \todo find another way when not all default values are saved or (unknown from the reader !!!)
   MemIOCallback TmpBuf(GetSize() - 6);
-  for (size_t Index = 0; Index < ElementList.size(); Index++) {
-    (ElementList[Index])->Render(TmpBuf, true, false, true);
+  for (auto Index : ElementList) {
+    Index->Render(TmpBuf, true, false, true);
   }
   aChecksum.FillCRC32(TmpBuf.GetDataBuffer(), TmpBuf.GetDataBufferSize());
   return (aChecksum.GetCrc32() == Checksum.GetCrc32());

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -60,8 +60,8 @@ EbmlMaster::EbmlMaster(const EbmlMaster & ElementToClone)
  ,Checksum(ElementToClone.Checksum)
 {
   // add a clone of the list
-  std::vector<EbmlElement *>::const_iterator Itr = ElementToClone.ElementList.begin();
-  std::vector<EbmlElement *>::iterator myItr = ElementList.begin();
+  auto Itr = ElementToClone.ElementList.begin();
+  auto myItr = ElementList.begin();
   while (Itr != ElementToClone.ElementList.end())
   {
     *myItr = (*Itr)->Clone();
@@ -240,7 +240,7 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
     }
 
     if (childElement->IsMaster()) {
-      EbmlMaster *childMaster = (EbmlMaster *)childElement;
+      auto childMaster = (EbmlMaster *)childElement;
 
       std::vector<std::string> childMissingElements = childMaster->FindAllMissingElements();
       for (size_t s = 0; s < childMissingElements.size(); s++)
@@ -525,7 +525,7 @@ processCrc:
 void EbmlMaster::Remove(size_t Index)
 {
   if (Index < ElementList.size()) {
-    std::vector<EbmlElement *>::iterator Itr = ElementList.begin();
+    auto Itr = ElementList.begin();
     while (Index-- > 0) {
       ++Itr;
     }
@@ -562,7 +562,7 @@ bool EbmlMaster::VerifyChecksum() const
 
 bool EbmlMaster::InsertElement(EbmlElement & element, size_t position)
 {
-  std::vector<EbmlElement *>::iterator Itr = ElementList.begin();
+  auto Itr = ElementList.begin();
   while (Itr != ElementList.end() && position--)
   {
     ++Itr;
@@ -576,7 +576,7 @@ bool EbmlMaster::InsertElement(EbmlElement & element, size_t position)
 
 bool EbmlMaster::InsertElement(EbmlElement & element, const EbmlElement & before)
 {
-  std::vector<EbmlElement *>::iterator Itr = ElementList.begin();
+  auto Itr = ElementList.begin();
   while (Itr != ElementList.end() && *Itr != &before)
   {
     ++Itr;

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -260,20 +260,19 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
 
 EbmlElement *EbmlMaster::FindElt(const EbmlCallbacks & Callbacks) const
 {
-  for (auto Element : ElementList) {
-    if (EbmlId(*Element) == EBML_INFO_ID(Callbacks))
-      return Element;
-  }
+  auto it = std::find_if(ElementList.begin(), ElementList.end(), [&](const EbmlElement *Element)
+    { return EbmlId(*Element) == EBML_INFO_ID(Callbacks); });
 
-  return nullptr;
+  return it != ElementList.end() ? *it : nullptr;
 }
 
 EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCreateIfNull)
 {
-  for (auto Element : ElementList) {
-    if (Element && EbmlId(*Element) == EBML_INFO_ID(Callbacks))
-      return Element;
-  }
+  auto it = std::find_if(ElementList.begin(), ElementList.end(), [&](const EbmlElement *Element)
+    { return Element && EbmlId(*Element) == EBML_INFO_ID(Callbacks); });
+
+  if (it != ElementList.end())
+    return *it;
 
   if (bCreateIfNull) {
     // add the element
@@ -293,12 +292,10 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCre
 
 EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
 {
-  for (auto Element : ElementList) {
-    if (EbmlId(*Element) == EBML_INFO_ID(Callbacks))
-      return Element;
-  }
+  auto it = std::find_if(ElementList.begin(), ElementList.end(), [&](const EbmlElement *Element)
+    { return EbmlId(*Element) == EBML_INFO_ID(Callbacks); });
 
-  return nullptr;
+  return it != ElementList.end() ? *it : nullptr;
 }
 
 /*!

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -242,8 +242,7 @@ std::vector<std::string> EbmlMaster::FindAllMissingElements()
       auto childMaster = (EbmlMaster *)childElement;
 
       std::vector<std::string> childMissingElements = childMaster->FindAllMissingElements();
-      for (auto & childMissingElement : childMissingElements)
-        missingElements.push_back(childMissingElement);
+      std::copy(childMissingElements.begin(), childMissingElements.end(), std::back_inserter(missingElements));
     }
   }
   unsigned int EltIdx;

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -65,13 +65,6 @@ EbmlSInteger::EbmlSInteger(int64 aDefaultValue)
   SetDefaultIsSet();
 }
 
-EbmlSInteger::EbmlSInteger(const EbmlSInteger & ElementToClone)
-  :EbmlElement(ElementToClone)
-  ,Value(ElementToClone.Value)
-  ,DefaultValue(ElementToClone.DefaultValue)
-{
-}
-
 EbmlSInteger::operator int8() const {return  int8(Value);}
 EbmlSInteger::operator int16() const {return int16(Value);}
 EbmlSInteger::operator int32() const {return int32(Value);}

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -163,8 +163,8 @@ bool EbmlSInteger::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->Value < static_cast<const EbmlSInteger *>(Cmp)->Value;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -51,7 +51,7 @@ ToSigned(uint64 u) {
   return static_cast<int64>(u - std::numeric_limits<int64>::min()) + std::numeric_limits<int64>::min();
 }
 
-}
+} // namespace
 
 START_LIBEBML_NAMESPACE
 

--- a/src/EbmlStream.cpp
+++ b/src/EbmlStream.cpp
@@ -41,9 +41,6 @@ EbmlStream::EbmlStream(IOCallback & DataStream)
   :Stream(DataStream)
 {}
 
-EbmlStream::~EbmlStream()
-{}
-
 EbmlElement * EbmlStream::FindNextID(const EbmlCallbacks & ClassInfos, uint64 MaxDataSize)
 {
   return EbmlElement::FindNextID(Stream, ClassInfos, MaxDataSize);

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -63,13 +63,6 @@ EbmlString::EbmlString(const std::string & aDefaultValue)
 /*!
   \todo Cloning should be on the same exact type !
 */
-EbmlString::EbmlString(const EbmlString & ElementToClone)
-  :EbmlElement(ElementToClone)
-  ,Value(ElementToClone.Value)
-  ,DefaultValue(ElementToClone.DefaultValue)
-{
-}
-
 void EbmlString::SetDefaultValue(std::string & aValue)
 {
   assert(!DefaultISset());

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -95,7 +95,7 @@ filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, b
 
   if (Result < GetDefaultSize()) {
     // pad the rest with 0
-    binary *Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
+    auto Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
     if (Pad == NULL) {
       return Result;
     }
@@ -149,7 +149,7 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = "";
       SetValueIsSet();
     } else {
-      char *Buffer = new (std::nothrow) char[GetSize() + 1];
+      auto Buffer = new (std::nothrow) char[GetSize() + 1];
       if (Buffer == NULL) {
         // unable to store the data, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -96,7 +96,7 @@ filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, b
   if (Result < GetDefaultSize()) {
     // pad the rest with 0
     auto Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
-    if (Pad == NULL) {
+    if (Pad == nullptr) {
       return Result;
     }
     memset(Pad, 0x00, GetDefaultSize() - Result);
@@ -150,7 +150,7 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
       SetValueIsSet();
     } else {
       auto Buffer = new (std::nothrow) char[GetSize() + 1];
-      if (Buffer == NULL) {
+      if (Buffer == nullptr) {
         // unable to store the data, skip it
         input.setFilePointer(GetSize(), seek_current);
       } else {

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -153,8 +153,8 @@ bool EbmlUInteger::IsSmallerThan(const EbmlElement *Cmp) const
 {
   if (EbmlId(*this) == EbmlId(*Cmp))
     return this->Value < static_cast<const EbmlUInteger *>(Cmp)->Value;
-  else
-    return false;
+
+  return false;
 }
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -50,13 +50,6 @@ EbmlUInteger::EbmlUInteger(uint64 aDefaultValue)
   SetDefaultIsSet();
 }
 
-EbmlUInteger::EbmlUInteger(const EbmlUInteger & ElementToClone)
-  :EbmlElement(ElementToClone)
-  ,Value(ElementToClone.Value)
-  ,DefaultValue(ElementToClone.DefaultValue)
-{
-}
-
 void EbmlUInteger::SetDefaultValue(uint64 aValue)
 {
   assert(!DefaultISset());

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -214,13 +214,6 @@ EbmlUnicodeString::EbmlUnicodeString(const UTFstring & aDefaultValue)
   SetDefaultIsSet();
 }
 
-EbmlUnicodeString::EbmlUnicodeString(const EbmlUnicodeString & ElementToClone)
-  :EbmlElement(ElementToClone)
-  ,Value(ElementToClone.Value)
-  ,DefaultValue(ElementToClone.DefaultValue)
-{
-}
-
 void EbmlUnicodeString::SetDefaultValue(UTFstring & aValue)
 {
   assert(!DefaultISset());

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -47,19 +47,19 @@ START_LIBEBML_NAMESPACE
 
 UTFstring::UTFstring()
   :_Length(0)
-  ,_Data(NULL)
+  ,_Data(nullptr)
 {}
 
 UTFstring::UTFstring(const wchar_t * _aBuf)
   :_Length(0)
-  ,_Data(NULL)
+  ,_Data(nullptr)
 {
   *this = _aBuf;
 }
 
 UTFstring::UTFstring(std::wstring const &_aBuf)
   :_Length(0)
-  ,_Data(NULL)
+  ,_Data(nullptr)
 {
   *this = _aBuf.c_str();
 }
@@ -71,7 +71,7 @@ UTFstring::~UTFstring()
 
 UTFstring::UTFstring(const UTFstring & _aBuf)
   :_Length(0)
-  ,_Data(NULL)
+  ,_Data(nullptr)
 {
   *this = _aBuf.c_str();
 }
@@ -88,7 +88,7 @@ UTFstring::operator const wchar_t*() const {return _Data;}
 UTFstring & UTFstring::operator=(const wchar_t * _aBuf)
 {
   delete [] _Data;
-  if (_aBuf == NULL) {
+  if (_aBuf == nullptr) {
     _Data = new wchar_t[1];
     _Data[0] = 0;
     UpdateFromUCS2();
@@ -120,9 +120,9 @@ UTFstring & UTFstring::operator=(wchar_t _aChar)
 
 bool UTFstring::operator==(const UTFstring& _aStr) const
 {
-  if ((_Data == NULL) && (_aStr._Data == NULL))
+  if ((_Data == nullptr) && (_aStr._Data == nullptr))
     return true;
-  if ((_Data == NULL) || (_aStr._Data == NULL))
+  if ((_Data == nullptr) || (_aStr._Data == nullptr))
     return false;
   return wcscmp_internal(_Data, _aStr._Data);
 }
@@ -250,7 +250,7 @@ filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRende
   if (Result < GetDefaultSize()) {
     // pad the rest with 0
     auto Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
-    if (Pad != NULL) {
+    if (Pad != nullptr) {
       memset(Pad, 0x00, GetDefaultSize() - Result);
       output.writeFully(Pad, GetDefaultSize() - Result);
 
@@ -315,7 +315,7 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
       SetValueIsSet();
     } else {
       auto Buffer = new (std::nothrow) char[GetSize()+1];
-      if (Buffer == NULL) {
+      if (Buffer == nullptr) {
         // impossible to read, skip it
         input.setFilePointer(GetSize(), seek_current);
       } else {

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -249,7 +249,7 @@ filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRende
 
   if (Result < GetDefaultSize()) {
     // pad the rest with 0
-    binary *Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
+    auto Pad = new (std::nothrow) binary[GetDefaultSize() - Result];
     if (Pad != NULL) {
       memset(Pad, 0x00, GetDefaultSize() - Result);
       output.writeFully(Pad, GetDefaultSize() - Result);
@@ -314,7 +314,7 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = UTFstring::value_type(0);
       SetValueIsSet();
     } else {
-      char *Buffer = new (std::nothrow) char[GetSize()+1];
+      auto Buffer = new (std::nothrow) char[GetSize()+1];
       if (Buffer == NULL) {
         // impossible to read, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -50,7 +50,7 @@ void IOCallback::writeFully(const void*Buffer,size_t Size)
   if (Size == 0)
     return;
 
-  if (Buffer == NULL)
+  if (Buffer == nullptr)
     throw;
 
   if(write(Buffer,Size) != Size) {
@@ -66,7 +66,7 @@ void IOCallback::writeFully(const void*Buffer,size_t Size)
 
 void IOCallback::readFully(void*Buffer,size_t Size)
 {
-  if(Buffer == NULL)
+  if(Buffer == nullptr)
     throw;
 
   if(read(Buffer,Size) != Size) {

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -41,7 +41,7 @@ START_LIBEBML_NAMESPACE
 MemIOCallback::MemIOCallback(uint64 DefaultSize)
 {
   //The default size of the buffer is 128 bytes
-  dataBuffer = (binary *)malloc(DefaultSize);
+  dataBuffer = static_cast<binary *>(malloc(DefaultSize));
   if (dataBuffer == nullptr) {
     mOk = false;
     std::stringstream Msg;
@@ -97,7 +97,7 @@ size_t MemIOCallback::write(const void *Buffer, size_t Size)
 {
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
-    dataBuffer = (binary *)realloc((void *)dataBuffer, dataBufferPos + Size);
+    dataBuffer = static_cast<binary *>(realloc((void *)dataBuffer, dataBufferPos + Size));
   }
   memcpy(dataBuffer+dataBufferPos, Buffer, Size);
   dataBufferPos += Size;
@@ -111,7 +111,7 @@ uint32 MemIOCallback::write(IOCallback & IOToRead, size_t Size)
 {
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
-    dataBuffer = (binary *)realloc((void *)dataBuffer, dataBufferPos + Size);
+    dataBuffer = static_cast<binary *>(realloc((void *)dataBuffer, dataBufferPos + Size));
   }
   IOToRead.readFully(&dataBuffer[dataBufferPos], Size);
   dataBufferTotalSize = Size;

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -42,7 +42,7 @@ MemIOCallback::MemIOCallback(uint64 DefaultSize)
 {
   //The default size of the buffer is 128 bytes
   dataBuffer = (binary *)malloc(DefaultSize);
-  if (dataBuffer == NULL) {
+  if (dataBuffer == nullptr) {
     mOk = false;
     std::stringstream Msg;
     Msg << "Failed to alloc memory block of size ";
@@ -59,13 +59,13 @@ MemIOCallback::MemIOCallback(uint64 DefaultSize)
 
 MemIOCallback::~MemIOCallback()
 {
-  if (dataBuffer != NULL)
+  if (dataBuffer != nullptr)
     free(dataBuffer);
 }
 
 uint32 MemIOCallback::read(void *Buffer, size_t Size)
 {
-  if (Buffer == NULL || Size < 1)
+  if (Buffer == nullptr || Size < 1)
     return 0;
   //If the size is larger than than the amount left in the buffer
   if (Size + dataBufferPos > dataBufferTotalSize) {

--- a/src/MemReadIOCallback.cpp
+++ b/src/MemReadIOCallback.cpp
@@ -54,9 +54,6 @@ MemReadIOCallback::MemReadIOCallback(MemReadIOCallback const &Mem) {
   Init(Mem.mPtr, Mem.mEnd - Mem.mPtr);
 }
 
-MemReadIOCallback::~MemReadIOCallback() {
-}
-
 void
 MemReadIOCallback::Init(void const *Ptr,
                         size_t Size) {

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -156,11 +156,11 @@ SafeReadIOCallback::Skip(size_t Count) {
 }
 
 void
-SafeReadIOCallback::Seek(size_t Offset) {
-  mIO->setFilePointer(Offset);
+SafeReadIOCallback::Seek(size_t Position) {
+  mIO->setFilePointer(Position);
   uint64 ActualPosition = mIO->getFilePointer();
-  if (ActualPosition != Offset)
-    throw EndOfStreamX(ActualPosition - Offset);
+  if (ActualPosition != Position)
+    throw EndOfStreamX(ActualPosition - Position);
 }
 
 void

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -94,7 +94,7 @@ StdIOCallback::StdIOCallback(const char*Path, const open_mode aMode)
 }
 
 
-StdIOCallback::~StdIOCallback()throw()
+StdIOCallback::~StdIOCallback() noexcept
 {
   close();
 }

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -129,7 +129,7 @@ void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
   if(fseek(File,Offset,Mode)!=0) {
 #if !defined(__GNUC__) || (__GNUC__ > 2)
     ostringstream Msg;
-    Msg<<"Failed to seek file "<<File<<" to offset "<<(unsigned long)Offset<<" in mode "<<Mode;
+    Msg<<"Failed to seek file "<<File<<" to offset "<<static_cast<unsigned long>(Offset)<<" in mode "<<Mode;
     throw CRTError(Msg.str());
 #else // GCC2
     mCurrentPosition = ftell(File);

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -62,7 +62,7 @@ CRTError::CRTError(const std::string & Description,int nError)
 
 StdIOCallback::StdIOCallback(const char*Path, const open_mode aMode)
 {
-  assert(Path!=0);
+  assert(Path!=nullptr);
 
   const char *Mode;
   switch (aMode) {
@@ -83,7 +83,7 @@ StdIOCallback::StdIOCallback(const char*Path, const open_mode aMode)
   }
 
   File=fopen(Path,Mode);
-  if(File==0) {
+  if(File==nullptr) {
 #if !defined(__GNUC__) || (__GNUC__ > 2)
     stringstream Msg;
     Msg<<"Can't open stdio file \""<<Path<<"\" in mode \""<<Mode<<"\"";
@@ -103,7 +103,7 @@ StdIOCallback::~StdIOCallback()throw()
 
 uint32 StdIOCallback::read(void*Buffer,size_t Size)
 {
-  assert(File!=0);
+  assert(File!=nullptr);
 
   size_t result = fread(Buffer, 1, Size, File);
   mCurrentPosition += result;
@@ -112,7 +112,7 @@ uint32 StdIOCallback::read(void*Buffer,size_t Size)
 
 void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
 {
-  assert(File!=0);
+  assert(File!=nullptr);
 
   // There is a numeric cast in the boost library, which would be quite nice for this checking
   /*
@@ -151,7 +151,7 @@ void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
 
 size_t StdIOCallback::write(const void*Buffer,size_t Size)
 {
-  assert(File!=0);
+  assert(File!=nullptr);
   uint32 Result = fwrite(Buffer,1,Size,File);
   mCurrentPosition += Result;
   return Result;
@@ -159,7 +159,7 @@ size_t StdIOCallback::write(const void*Buffer,size_t Size)
 
 uint64 StdIOCallback::getFilePointer()
 {
-  assert(File!=0);
+  assert(File!=nullptr);
 
 #if 0
   long Result=ftell(File);
@@ -177,7 +177,7 @@ uint64 StdIOCallback::getFilePointer()
 
 void StdIOCallback::close()
 {
-  if(File==0)
+  if(File==nullptr)
     return;
 
   if(fclose(File)!=0) {
@@ -188,7 +188,7 @@ void StdIOCallback::close()
 #endif // GCC2
   }
 
-  File=0;
+  File=nullptr;
 }
 
 END_LIBEBML_NAMESPACE


### PR DESCRIPTION
This is a complementary PR to https://github.com/Matroska-Org/libebml/pull/64 which includes C++11 changes.

Placing as a draft. While libebml does not compile with -std=c++98 , there doesn't seem to be an official stance on C++11.