### PR TITLE
Add options for building and installing shared, static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(ebml VERSION 1.4.0)
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
 option(ENABLE_WIN32_IO "Build the Windows I/O helper class" OFF)
+option(DISABLE_SHARED_LIBS "Disable build and install shared libraries" OFF)
+option(DISABLE_STATIC_LIBS "Disable build and install static libraries" OFF)
 
 include(GNUInstallDirs)
 
@@ -72,50 +74,82 @@ set(libebml_PUBLIC_HEADERS
 
 set(libebml_C_PUBLIC_HEADERS ebml/c/libebml_t.h)
 
-add_library(ebml ${libebml_SOURCES} ${libebml_PUBLIC_HEADERS} ${libebml_C_PUBLIC_HEADERS})
-if(WIN32)
-  include(CheckIncludeFile)
-  check_include_file(winapifamily.h HAVE_WINAPIFAMILY_H)
-  if(HAVE_WINAPIFAMILY_H)
-    target_compile_definitions(ebml PUBLIC HAVE_WINAPIFAMILY_H)
-  endif()
-endif()
-set_target_properties(ebml PROPERTIES
-  VERSION 5.0.0
-  SOVERSION 5
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN ON
-)
-target_include_directories(ebml
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-if(MSVC)
-  target_compile_definitions(ebml PRIVATE _CRT_SECURE_NO_WARNINGS)
-endif()
 
 include(GenerateExportHeader)
-generate_export_header(ebml EXPORT_MACRO_NAME EBML_DLL_API)
-target_sources(ebml
-  PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h
-)
+foreach (TYPE IN ITEMS STATIC SHARED)
+  if (NOT DISABLE_${TYPE}_LIBS)
 
-if(NOT BUILD_SHARED_LIBS)
-  target_compile_definitions(ebml PUBLIC EBML_STATIC_DEFINE)
+    set(type_suffix "")
+    if ("${TYPE}" STREQUAL "STATIC")
+      string(TOLOWER "${TYPE}" type)
+      set(type_suffix "-${type}")
+    endif()
+
+    add_library(ebml${type_suffix} ${TYPE}
+      ${libebml_SOURCES}
+      ${libebml_PUBLIC_HEADERS}
+      ${libebml_C_PUBLIC_HEADERS})
+
+    if(WIN32)
+      include(CheckIncludeFile)
+      check_include_file(winapifamily.h HAVE_WINAPIFAMILY_H)
+      if(HAVE_WINAPIFAMILY_H)
+        target_compile_definitions(ebml${type_suffix} PUBLIC HAVE_WINAPIFAMILY_H)
+      endif()
+    endif()
+
+    target_include_directories(ebml${type_suffix}
+      PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+      PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+    generate_export_header(ebml${type_suffix} EXPORT_MACRO_NAME EBML_DLL_API BASE_NAME ebml)
+    target_sources(ebml${type_suffix}
+      PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h)
+
+    if(MSVC)
+      target_compile_definitions(ebml${type_suffix} PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif()
+  endif()
+endforeach()
+
+if(NOT DISABLE_SHARED_LIBS)
+  set_target_properties(ebml PROPERTIES
+    VERSION 5.0.0
+    SOVERSION 5
+    OUTPUT_NAME ebml
+    DEFINE_SYMBOL "EBML_DLL_EXPORT"
+    VISIBILITY_INLINES_HIDDEN ON
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden)
+
+  target_compile_definitions(ebml
+      PUBLIC EBML_DLL
+      PRIVATE EBML_DLL_EXPORT)
+
+  install(TARGETS ebml
+    EXPORT EBMLTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-install(TARGETS ebml
-  EXPORT EBMLTargets
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(NOT DISABLE_STATIC_LIBS)
+  set_target_properties(ebml-static PROPERTIES OUTPUT_NAME ebml)
+  target_compile_definitions(ebml-static PUBLIC EBML_STATIC_DEFINE)
+  install(TARGETS ebml-static
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 install(FILES ${libebml_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
 install(FILES ${libebml_C_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml/c)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
+if(NOT DISABLE_SHARED_LIBS)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
+endif()
 
 if(NOT DISABLE_PKGCONFIG)
   set(prefix ${CMAKE_INSTALL_PREFIX})
@@ -126,7 +160,7 @@ if(NOT DISABLE_PKGCONFIG)
   if (HAVE_WINAPIFAMILY_H)
     set(WINAPIFAMILY_PC -DHAVE_WINAPIFAMILY_H)
   endif()
-  if(NOT BUILD_SHARED_LIBS)
+  if(NOT DISABLE_STATIC_LIBS)
     set(STATIC_DEFINE_CFLAGS -DEBML_STATIC_DEFINE)
   endif()
   configure_file(libebml.pc.in libebml.pc @ONLY)
@@ -139,7 +173,9 @@ if(NOT DISABLE_CMAKE_CONFIG)
   configure_package_config_file(EBMLConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/EBMLConfig.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
   write_basic_package_version_file(EBMLConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+if(NOT DISABLE_SHARED_LIBS)
   install(EXPORT EBMLTargets NAMESPACE EBML:: DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
+endif()
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/EBMLConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/EBMLConfigVersion.cmake


### PR DESCRIPTION
This PR adds cmake options for building and installing shared and/or static libraries.  All combinations were tested on a UNIX-like system. Therefore a test under Windows is missing.