### PR TITLE
Add fix for heap buffer overflow bug on 32bit builds

### DIFF
--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -138,7 +138,7 @@ uint64 EbmlString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
-    if (GetSize() == 0) {
+    if (GetSize() == 0 || GetSize() + 1 >= SIZE_MAX) {
       Value = "";
       SetValueIsSet();
     } else {

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -303,7 +303,7 @@ uint64 EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
-    if (GetSize() == 0) {
+    if (GetSize() == 0 || GetSize() + 1 >= SIZE_MAX) {
       Value = UTFstring::value_type(0);
       SetValueIsSet();
     } else {


### PR DESCRIPTION
Possible fix for bug #74 "Ebml[Unicode]String::ReadData heap overflow bug on 32bit builds"