### PR TITLE
Fix misc reading overflows

### DIFF
--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -97,7 +97,7 @@ filepos_t EbmlBinary::ReadData(IOCallback & input, ScopeMode ReadFully)
     return 0;
   }
 
-  Data = static_cast<binary *>(malloc(GetSize()));
+  Data = (GetSize() < SIZE_MAX) ? static_cast<binary *>(malloc(GetSize())) : nullptr;
   if (Data == nullptr)
     throw CRTError(std::string("Error allocating data"));
   SetValueIsSet();

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -233,7 +233,7 @@ filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bo
 filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
-    auto Buffer = new (std::nothrow) binary[GetSize()];
+    auto Buffer = (GetSize() < SIZE_MAX) ? new (std::nothrow) binary[GetSize()] : nullptr;
     if (Buffer == nullptr) {
       // impossible to read, skip it
       input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -233,15 +233,11 @@ filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bo
 filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
-    auto Buffer = (GetSize() < SIZE_MAX) ? new (std::nothrow) binary[GetSize()] : nullptr;
-    if (Buffer == nullptr) {
+    if (GetSize() != 4) {
       // impossible to read, skip it
       input.setFilePointer(GetSize(), seek_current);
     } else {
-      input.readFully(Buffer, GetSize());
-
-      memcpy((void *)&m_crc_final, Buffer, 4);
-      delete [] Buffer;
+      input.readFully(&m_crc_final, GetSize());
       SetValueIsSet();
     }
   }

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -232,15 +232,17 @@ filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bo
 
 filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
-    if (GetSize() != 4) {
-      // impossible to read, skip it
-      input.setFilePointer(GetSize(), seek_current);
-    } else {
-      input.readFully(&m_crc_final, GetSize());
-      SetValueIsSet();
-    }
+  if (ReadFully == SCOPE_NO_DATA)
+    return GetSize();
+
+  if (GetSize() != 4) {
+    // impossible to read, skip it
+    input.setFilePointer(GetSize(), seek_current);
+    return GetSize();
   }
+
+  input.readFully(&m_crc_final, GetSize());
+  SetValueIsSet();
 
   return GetSize();
 }

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -54,17 +54,17 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
   if (GetSize() != 8) {
     // impossible to read, skip it
     input.setFilePointer(GetSize(), seek_current);
-  } else {
-    binary Buffer[8];
-    input.readFully(Buffer, GetSize());
-
-    big_int64 b64;
-    b64.Eval(Buffer);
-
-    myDate = b64;
-    SetValueIsSet();
+    return GetSize();
   }
 
+  binary Buffer[8];
+  input.readFully(Buffer, GetSize());
+
+  big_int64 b64;
+  b64.Eval(Buffer);
+
+  myDate = b64;
+  SetValueIsSet();
   return GetSize();
 }
 

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -51,6 +51,8 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
     return GetSize();
 
   assert(GetSize() == 8);
+  if (GetSize() != 8)
+    return GetSize();
   binary Buffer[8];
   input.readFully(Buffer, GetSize());
 

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -51,8 +51,10 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
     return GetSize();
 
   assert(GetSize() == 8);
-  if (GetSize() != 8)
-    return GetSize();
+  if (GetSize() != 8) {
+    // impossible to read, skip it
+    input.setFilePointer(GetSize(), seek_current);
+  } else {
   binary Buffer[8];
   input.readFully(Buffer, GetSize());
 
@@ -61,6 +63,7 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
 
   myDate = b64;
   SetValueIsSet();
+  }
 
   return GetSize();
 }

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -55,14 +55,14 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
     // impossible to read, skip it
     input.setFilePointer(GetSize(), seek_current);
   } else {
-  binary Buffer[8];
-  input.readFully(Buffer, GetSize());
+    binary Buffer[8];
+    input.readFully(Buffer, GetSize());
 
-  big_int64 b64;
-  b64.Eval(Buffer);
+    big_int64 b64;
+    b64.Eval(Buffer);
 
-  myDate = b64;
-  SetValueIsSet();
+    myDate = b64;
+    SetValueIsSet();
   }
 
   return GetSize();

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -115,25 +115,25 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
   if (ReadFully != SCOPE_NO_DATA) {
     assert(GetSize() == 4 || GetSize() == 8);
     if (GetSize() == 4 || GetSize() == 8) {
-    binary Buffer[8];
-    input.readFully(Buffer, GetSize());
+      binary Buffer[8];
+      input.readFully(Buffer, GetSize());
 
-    if (GetSize() == 4) {
-      big_int32 TmpRead;
-      TmpRead.Eval(Buffer);
-      auto tmpp = int32(TmpRead);
-      float val;
-      memcpy(&val, &tmpp, 4);
-      Value = static_cast<double>(val);
-      SetValueIsSet();
-    } else if (GetSize() == 8) {
-      big_int64 TmpRead;
-      TmpRead.Eval(Buffer);
-      auto tmpp = int64(TmpRead);
-      double val;
-      memcpy(&val, &tmpp, 8);
-      Value = val;
-      SetValueIsSet();
+      if (GetSize() == 4) {
+        big_int32 TmpRead;
+        TmpRead.Eval(Buffer);
+        auto tmpp = int32(TmpRead);
+        float val;
+        memcpy(&val, &tmpp, 4);
+        Value = static_cast<double>(val);
+        SetValueIsSet();
+      } else if (GetSize() == 8) {
+        big_int64 TmpRead;
+        TmpRead.Eval(Buffer);
+        auto tmpp = int64(TmpRead);
+        double val;
+        memcpy(&val, &tmpp, 8);
+        Value = val;
+        SetValueIsSet();
       } else {
         // impossible to read, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -134,7 +134,10 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
       memcpy(&val, &tmpp, 8);
       Value = val;
       SetValueIsSet();
-    }
+      } else {
+        // impossible to read, skip it
+        input.setFilePointer(GetSize(), seek_current);
+      }
     }
   }
 

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -113,8 +113,9 @@ uint64 EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
 filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
   if (ReadFully != SCOPE_NO_DATA) {
-    binary Buffer[20];
-    assert(GetSize() <= 20);
+    assert(GetSize() == 4 || GetSize() == 8);
+    if (GetSize() == 4 || GetSize() == 8) {
+    binary Buffer[8];
     input.readFully(Buffer, GetSize());
 
     if (GetSize() == 4) {
@@ -133,6 +134,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
       memcpy(&val, &tmpp, 8);
       Value = val;
       SetValueIsSet();
+    }
     }
   }
 

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -112,33 +112,35 @@ uint64 EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
 */
 filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
-    assert(GetSize() == 4 || GetSize() == 8);
-    if (GetSize() == 4 || GetSize() == 8) {
-      binary Buffer[8];
-      input.readFully(Buffer, GetSize());
+  if (ReadFully == SCOPE_NO_DATA)
+    return GetSize();
 
-      if (GetSize() == 4) {
-        big_int32 TmpRead;
-        TmpRead.Eval(Buffer);
-        auto tmpp = int32(TmpRead);
-        float val;
-        memcpy(&val, &tmpp, 4);
-        Value = static_cast<double>(val);
-        SetValueIsSet();
-      } else if (GetSize() == 8) {
-        big_int64 TmpRead;
-        TmpRead.Eval(Buffer);
-        auto tmpp = int64(TmpRead);
-        double val;
-        memcpy(&val, &tmpp, 8);
-        Value = val;
-        SetValueIsSet();
-      } else {
-        // impossible to read, skip it
-        input.setFilePointer(GetSize(), seek_current);
-      }
-    }
+  assert(GetSize() == 4 || GetSize() == 8);
+  if (GetSize() != 4 && GetSize() != 8) {
+    // impossible to read, skip it
+    input.setFilePointer(GetSize(), seek_current);
+    return GetSize();
+  }
+
+  binary Buffer[8];
+  input.readFully(Buffer, GetSize());
+
+  if (GetSize() == 4) {
+    big_int32 TmpRead;
+    TmpRead.Eval(Buffer);
+    auto tmpp = int32(TmpRead);
+    float val;
+    memcpy(&val, &tmpp, 4);
+    Value = static_cast<double>(val);
+    SetValueIsSet();
+  } else {
+    big_int64 TmpRead;
+    TmpRead.Eval(Buffer);
+    auto tmpp = int64(TmpRead);
+    double val;
+    memcpy(&val, &tmpp, 8);
+    Value = val;
+    SetValueIsSet();
   }
 
   return GetSize();

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -133,7 +133,7 @@ uint64 EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 
 filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
+  if (ReadFully != SCOPE_NO_DATA && GetSize() <= 8) {
     binary Buffer[8];
     input.readFully(Buffer, GetSize());
 

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -133,7 +133,11 @@ uint64 EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 
 filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA && GetSize() <= 8) {
+  if (ReadFully != SCOPE_NO_DATA) {
+    if (GetSize() > 8) {
+      // impossible to read, skip it
+      input.setFilePointer(GetSize(), seek_current);
+    } else {
     binary Buffer[8];
     input.readFully(Buffer, GetSize());
 
@@ -147,6 +151,7 @@ filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
     Value = ToSigned(TempValue);
 
     SetValueIsSet();
+    }
   }
 
   return GetSize();

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -133,27 +133,28 @@ uint64 EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 
 filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
-    if (GetSize() > 8) {
-      // impossible to read, skip it
-      input.setFilePointer(GetSize(), seek_current);
-    } else {
-      binary Buffer[8];
-      input.readFully(Buffer, GetSize());
+  if (ReadFully == SCOPE_NO_DATA)
+    return GetSize();
 
-      uint64 TempValue = Buffer[0] & 0x80 ? std::numeric_limits<uint64>::max() : 0;
-
-      for (unsigned int i=0; i<GetSize(); i++) {
-        TempValue <<= 8;
-        TempValue |= Buffer[i];
-      }
-
-      Value = ToSigned(TempValue);
-
-      SetValueIsSet();
-    }
+  if (GetSize() > 8) {
+    // impossible to read, skip it
+    input.setFilePointer(GetSize(), seek_current);
+    return GetSize();
   }
 
+  binary Buffer[8];
+  input.readFully(Buffer, GetSize());
+
+  uint64 TempValue = Buffer[0] & 0x80 ? std::numeric_limits<uint64>::max() : 0;
+
+  for (unsigned int i=0; i<GetSize(); i++) {
+    TempValue <<= 8;
+    TempValue |= Buffer[i];
+  }
+
+  Value = ToSigned(TempValue);
+
+  SetValueIsSet();
   return GetSize();
 }
 

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -138,19 +138,19 @@ filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
       // impossible to read, skip it
       input.setFilePointer(GetSize(), seek_current);
     } else {
-    binary Buffer[8];
-    input.readFully(Buffer, GetSize());
+      binary Buffer[8];
+      input.readFully(Buffer, GetSize());
 
-    uint64 TempValue = Buffer[0] & 0x80 ? std::numeric_limits<uint64>::max() : 0;
+      uint64 TempValue = Buffer[0] & 0x80 ? std::numeric_limits<uint64>::max() : 0;
 
-    for (unsigned int i=0; i<GetSize(); i++) {
-      TempValue <<= 8;
-      TempValue |= Buffer[i];
-    }
+      for (unsigned int i=0; i<GetSize(); i++) {
+        TempValue <<= 8;
+        TempValue |= Buffer[i];
+      }
 
-    Value = ToSigned(TempValue);
+      Value = ToSigned(TempValue);
 
-    SetValueIsSet();
+      SetValueIsSet();
     }
   }
 

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -142,7 +142,7 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = "";
       SetValueIsSet();
     } else {
-      auto Buffer = new (std::nothrow) char[GetSize() + 1];
+      auto Buffer = (GetSize() + 1 < SIZE_MAX) ? new (std::nothrow) char[GetSize() + 1] : nullptr;
       if (Buffer == nullptr) {
         // unable to store the data, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -142,7 +142,7 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = "";
       SetValueIsSet();
     } else {
-      auto Buffer = (GetSize() + 1 < SIZE_MAX) ? new (std::nothrow) char[GetSize() + 1] : nullptr;
+      auto Buffer = (GetSize() + 1 < std::numeric_limits<size_t>::max()) ? new (std::nothrow) char[GetSize() + 1] : nullptr;
       if (Buffer == nullptr) {
         // unable to store the data, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -142,7 +142,7 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = "";
       SetValueIsSet();
     } else {
-      auto Buffer = (GetSize() + 1 < std::numeric_limits<size_t>::max()) ? new (std::nothrow) char[GetSize() + 1] : nullptr;
+      auto Buffer = (GetSize() + 1 < std::numeric_limits<std::size_t>::max()) ? new (std::nothrow) char[GetSize() + 1] : nullptr;
       if (Buffer == nullptr) {
         // unable to store the data, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -127,22 +127,24 @@ uint64 EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 
 filepos_t EbmlUInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
-    if (GetSize() > 8) {
-      // impossible to read, skip it
-      input.setFilePointer(GetSize(), seek_current);
-    } else {
-      binary Buffer[8];
-      input.readFully(Buffer, GetSize());
-      Value = 0;
+  if (ReadFully == SCOPE_NO_DATA)
+    return GetSize();
 
-      for (unsigned int i=0; i<GetSize(); i++) {
-        Value <<= 8;
-        Value |= Buffer[i];
-      }
-      SetValueIsSet();
-    }
+  if (GetSize() > 8) {
+    // impossible to read, skip it
+    input.setFilePointer(GetSize(), seek_current);
+    return GetSize();
   }
+
+  binary Buffer[8];
+  input.readFully(Buffer, GetSize());
+  Value = 0;
+
+  for (unsigned int i=0; i<GetSize(); i++) {
+    Value <<= 8;
+    Value |= Buffer[i];
+  }
+  SetValueIsSet();
 
   return GetSize();
 }

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -132,15 +132,15 @@ filepos_t EbmlUInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
       // impossible to read, skip it
       input.setFilePointer(GetSize(), seek_current);
     } else {
-    binary Buffer[8];
-    input.readFully(Buffer, GetSize());
-    Value = 0;
+      binary Buffer[8];
+      input.readFully(Buffer, GetSize());
+      Value = 0;
 
-    for (unsigned int i=0; i<GetSize(); i++) {
-      Value <<= 8;
-      Value |= Buffer[i];
-    }
-    SetValueIsSet();
+      for (unsigned int i=0; i<GetSize(); i++) {
+        Value <<= 8;
+        Value |= Buffer[i];
+      }
+      SetValueIsSet();
     }
   }
 

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -127,7 +127,7 @@ uint64 EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 
 filepos_t EbmlUInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
+  if (ReadFully != SCOPE_NO_DATA && GetSize() <= 8) {
     binary Buffer[8];
     input.readFully(Buffer, GetSize());
     Value = 0;

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -127,7 +127,11 @@ uint64 EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 
 filepos_t EbmlUInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA && GetSize() <= 8) {
+  if (ReadFully != SCOPE_NO_DATA) {
+    if (GetSize() > 8) {
+      // impossible to read, skip it
+      input.setFilePointer(GetSize(), seek_current);
+    } else {
     binary Buffer[8];
     input.readFully(Buffer, GetSize());
     Value = 0;
@@ -137,6 +141,7 @@ filepos_t EbmlUInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value |= Buffer[i];
     }
     SetValueIsSet();
+    }
   }
 
   return GetSize();

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -302,25 +302,26 @@ uint64 EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 */
 filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
 {
-  if (ReadFully != SCOPE_NO_DATA) {
-    if (GetSize() == 0) {
-      Value = UTFstring::value_type(0);
-      SetValueIsSet();
-    } else {
-      auto Buffer = (GetSize() + 1 < std::numeric_limits<std::size_t>::max()) ? new (std::nothrow) char[GetSize()+1] : nullptr;
-      if (Buffer == nullptr) {
-        // impossible to read, skip it
-        input.setFilePointer(GetSize(), seek_current);
-      } else {
-        input.readFully(Buffer, GetSize());
-        if (Buffer[GetSize()-1] != 0) {
-          Buffer[GetSize()] = 0;
-        }
+  if (ReadFully == SCOPE_NO_DATA)
+    return GetSize();
 
-        Value.SetUTF8(Buffer); // implicit conversion to std::string
-        delete [] Buffer;
-        SetValueIsSet();
+  if (GetSize() == 0) {
+    Value = UTFstring::value_type(0);
+    SetValueIsSet();
+  } else {
+    auto Buffer = (GetSize() + 1 < std::numeric_limits<std::size_t>::max()) ? new (std::nothrow) char[GetSize()+1] : nullptr;
+    if (Buffer == nullptr) {
+      // impossible to read, skip it
+      input.setFilePointer(GetSize(), seek_current);
+    } else {
+      input.readFully(Buffer, GetSize());
+      if (Buffer[GetSize()-1] != 0) {
+        Buffer[GetSize()] = 0;
       }
+
+      Value.SetUTF8(Buffer); // implicit conversion to std::string
+      delete [] Buffer;
+      SetValueIsSet();
     }
   }
 

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -307,7 +307,7 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = UTFstring::value_type(0);
       SetValueIsSet();
     } else {
-      auto Buffer = (GetSize() + 1 < SIZE_MAX) ? new (std::nothrow) char[GetSize()+1] : nullptr;
+      auto Buffer = (GetSize() + 1 < std::numeric_limits<size_t>::max()) ? new (std::nothrow) char[GetSize()+1] : nullptr;
       if (Buffer == nullptr) {
         // impossible to read, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -307,7 +307,7 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = UTFstring::value_type(0);
       SetValueIsSet();
     } else {
-      auto Buffer = new (std::nothrow) char[GetSize()+1];
+      auto Buffer = (GetSize() + 1 < SIZE_MAX) ? new (std::nothrow) char[GetSize()+1] : nullptr;
       if (Buffer == nullptr) {
         // impossible to read, skip it
         input.setFilePointer(GetSize(), seek_current);

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -307,7 +307,7 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
       Value = UTFstring::value_type(0);
       SetValueIsSet();
     } else {
-      auto Buffer = (GetSize() + 1 < std::numeric_limits<size_t>::max()) ? new (std::nothrow) char[GetSize()+1] : nullptr;
+      auto Buffer = (GetSize() + 1 < std::numeric_limits<std::size_t>::max()) ? new (std::nothrow) char[GetSize()+1] : nullptr;
       if (Buffer == nullptr) {
         // impossible to read, skip it
         input.setFilePointer(GetSize(), seek_current);


### PR DESCRIPTION
* some strings may read huge size into small memory buffers on 32 bits systems
* some integer/float are trying to read large sizes on fixed (8 bytes) buffers

There were some asserts but in release builds that won't trigger anything and just write in out of bounds memory.

If we can't read we just pretend that we have read the data. But `SetValueIsSet()` is not called. Just like we do for other errors we already handle.

Fixes #74 