### PR TITLE
treewide: remove custom fixed size types

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -43,12 +43,6 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-// ----- Added 10/15/2003 by jcsston from Zen -----
-#if defined (__BORLANDC__) //Maybe other compilers?
-  #include <mem.h>
-#endif //__BORLANDC__
-// ------------------------------------------------
-
 START_LIBEBML_NAMESPACE
 
 /*!
@@ -69,7 +63,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA);
     filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false);
 
-    void SetBuffer(const binary *Buffer, const uint32 BufferSize) {
+    void SetBuffer(const binary *Buffer, const std::uint32_t BufferSize) {
       Data = (binary *) Buffer;
       SetSize_(BufferSize);
       SetValueIsSet();
@@ -77,7 +71,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
 
     binary *GetBuffer() const {return Data;}
 
-    void CopyBuffer(const binary *Buffer, const uint32 BufferSize) {
+    void CopyBuffer(const binary *Buffer, const std::uint32_t BufferSize) {
       if (Data != nullptr)
         free(Data);
       Data = (binary *)malloc(BufferSize * sizeof(binary));

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -64,15 +64,15 @@ DECLARE_EBML_BINARY(EbmlCrc32)
       Use this to quickly check a CRC32 with some data
       \return True if inputCRC matches CRC32 generated from input data
     */
-    static bool CheckCRC(uint32 inputCRC, const binary *input, uint32 length);
+    static bool CheckCRC(std::uint32_t inputCRC, const binary *input, std::uint32_t length);
     /*!
       Calls Update() and Finalize(), use to create a CRC32 in one go
     */
-    void FillCRC32(const binary *input, uint32 length);
+    void FillCRC32(const binary *input, std::uint32_t length);
     /*!
       Add data to the CRC table, in other words process some data bit by bit
     */
-    void Update(const binary *input, uint32 length);
+    void Update(const binary *input, std::uint32_t length);
     /*!
       Use this with Update() to Finalize() or Complete the CRC32
     */
@@ -80,11 +80,11 @@ DECLARE_EBML_BINARY(EbmlCrc32)
     /*!
       Returns a uint32 that has the value of the CRC32
     */
-    uint32 GetCrc32() const {
+    std::uint32_t GetCrc32() const {
       return m_crc_final;
     }
 
-    void ForceCrc32(uint32 NewValue) { m_crc_final = NewValue; SetValueIsSet();}
+    void ForceCrc32(std::uint32_t NewValue) { m_crc_final = NewValue; SetValueIsSet();}
 
 #if defined(EBML_STRICT_API)
     private:
@@ -94,9 +94,9 @@ DECLARE_EBML_BINARY(EbmlCrc32)
     void ResetCRC();
     void UpdateByte(binary b);
 
-    static const uint32 m_tab[256];
-    uint32 m_crc;
-    uint32 m_crc_final;
+    static const std::uint32_t m_tab[256];
+    std::uint32_t m_crc;
+    std::uint32_t m_crc_final;
 
         EBML_CONCRETE_CLASS(EbmlCrc32)
 };

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -52,15 +52,15 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
       \brief set the date with a UNIX/C/EPOCH form
       \param NewDate UNIX/C date in UTC (no timezone)
     */
-    void SetEpochDate(int64 NewDate) {myDate = (NewDate - UnixEpochDelay) * 1000000000; SetValueIsSet();}
-    EbmlDate &SetValue(int64 NewValue) {SetEpochDate(NewValue); return *this;}
+    void SetEpochDate(std::int64_t NewDate) {myDate = (NewDate - UnixEpochDelay) * 1000000000; SetValueIsSet();}
+    EbmlDate &SetValue(std::int64_t NewValue) {SetEpochDate(NewValue); return *this;}
 
     /*!
       \brief get the date with a UNIX/C/EPOCH form
       \note the date is in UTC (no timezone)
     */
-    int64 GetEpochDate() const {return int64(myDate/1000000000 + UnixEpochDelay);}
-    int64 GetValue() const {return GetEpochDate();}
+    std::int64_t GetEpochDate() const {return std::int64_t(myDate/1000000000 + UnixEpochDelay);}
+    std::int64_t GetValue() const {return GetEpochDate();}
 
     virtual bool ValidateSize() const {return IsFiniteSize() && ((GetSize() == 8) || (GetSize() == 0));}
 
@@ -90,9 +90,9 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 #endif
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false);
 
-    int64 myDate; ///< internal format of the date
+    std::int64_t myDate; ///< internal format of the date
 
-    static const uint64 UnixEpochDelay;
+    static const std::uint64_t UnixEpochDelay;
 };
 
 END_LIBEBML_NAMESPACE

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -43,36 +43,36 @@ START_LIBEBML_NAMESPACE
 /*!
   \brief The size of the EBML-coded length
 */
-int EBML_DLL_API CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeIsFinite = true);
+int EBML_DLL_API CodedSizeLength(std::uint64_t Length, unsigned int SizeLength, bool bSizeIsFinite = true);
 
 /*!
   \brief The coded value of the EBML-coded length
   \note The size of OutBuffer must be 8 octets at least
 */
-int EBML_DLL_API CodedValueLength(uint64 Length, int CodedSize, binary * OutBuffer);
+int EBML_DLL_API CodedValueLength(std::uint64_t Length, int CodedSize, binary * OutBuffer);
 
 /*!
   \brief Read an EBML-coded value from a buffer
   \return the value read
 */
-uint64 EBML_DLL_API ReadCodedSizeValue(const binary * InBuffer, uint32 & BufferSize, uint64 & SizeUnknown);
+std::uint64_t EBML_DLL_API ReadCodedSizeValue(const binary * InBuffer, std::uint32_t & BufferSize, std::uint64_t & SizeUnknown);
 
 /*!
   \brief The size of the EBML-coded signed length
 */
-int EBML_DLL_API CodedSizeLengthSigned(int64 Length, unsigned int SizeLength);
+int EBML_DLL_API CodedSizeLengthSigned(std::int64_t Length, unsigned int SizeLength);
 
 /*!
   \brief The coded value of the EBML-coded signed length
   \note the size of OutBuffer must be 8 octets at least
 */
-int EBML_DLL_API CodedValueLengthSigned(int64 Length, int CodedSize, binary * OutBuffer);
+int EBML_DLL_API CodedValueLengthSigned(std::int64_t Length, int CodedSize, binary * OutBuffer);
 
 /*!
   \brief Read a signed EBML-coded value from a buffer
   \return the value read
 */
-int64 EBML_DLL_API ReadCodedSizeSignedValue(const binary * InBuffer, uint32 & BufferSize, uint64 & SizeUnknown);
+int64_t EBML_DLL_API ReadCodedSizeSignedValue(const binary * InBuffer, std::uint32_t & BufferSize, std::uint64_t & SizeUnknown);
 
 class EbmlStream;
 class EbmlSemanticContext;
@@ -332,7 +332,7 @@ typedef const class EbmlSemanticContext & (*_GetSemanticContext)();
 */
 class EBML_DLL_API EbmlSemanticContext {
   public:
-    EbmlSemanticContext(size_t aSize,
+    EbmlSemanticContext(std::size_t aSize,
       const EbmlSemantic *aMyTable,
       const EbmlSemanticContext *aUpTable,
       const _GetSemanticContext aGetGlobalContext,
@@ -346,10 +346,10 @@ class EBML_DLL_API EbmlSemanticContext {
         (MasterElt != aElt.MasterElt));
     }
 
-        inline size_t GetSize() const { return Size; }
+        inline std::size_t GetSize() const { return Size; }
         inline const EbmlCallbacks* GetMaster() const { return MasterElt; }
         inline const EbmlSemanticContext* Parent() const { return UpTable; }
-        const EbmlSemantic & GetSemantic(size_t i) const;
+        const EbmlSemantic & GetSemantic(std::size_t i) const;
 
     const _GetSemanticContext GetGlobalContext; ///< global elements supported at this level
 
@@ -357,7 +357,7 @@ class EBML_DLL_API EbmlSemanticContext {
     private:
 #endif
         const EbmlSemantic *MyTable; ///< First element in the table
-    size_t Size;          ///< number of elements in the table
+    std::size_t Size;          ///< number of elements in the table
     const EbmlSemanticContext *UpTable; ///< Parent element
     /// \todo replace with the global context directly
     const EbmlCallbacks *MasterElt;
@@ -369,20 +369,20 @@ class EBML_DLL_API EbmlSemanticContext {
 */
 class EBML_DLL_API EbmlElement {
   public:
-    EbmlElement(uint64 aDefaultSize, bool bValueSet = false);
+    EbmlElement(std::uint64_t aDefaultSize, bool bValueSet = false);
     virtual ~EbmlElement();
 
     /// Set the minimum length that will be used to write the element size (-1 = optimal)
     void SetSizeLength(int NewSizeLength) {SizeLength = NewSizeLength;}
     int GetSizeLength() const {return SizeLength;}
 
-    static EbmlElement * FindNextElement(IOCallback & DataStream, const EbmlSemanticContext & Context, int & UpperLevel, uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
-    static EbmlElement * FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, uint64 MaxDataSize);
+    static EbmlElement * FindNextElement(IOCallback & DataStream, const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
+    static EbmlElement * FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize);
 
     /*!
       \brief find the next element with the same ID
     */
-    EbmlElement * FindNext(IOCallback & DataStream, uint64 MaxDataSize);
+    EbmlElement * FindNext(IOCallback & DataStream, std::uint64_t MaxDataSize);
 
     EbmlElement * SkipData(EbmlStream & DataStream, const EbmlSemanticContext & Context, EbmlElement * TestReadElt = nullptr, bool AllowDummyElt = false);
 
@@ -407,11 +407,11 @@ class EBML_DLL_API EbmlElement {
 
     virtual bool ValidateSize() const = 0;
 
-    uint64 GetElementPosition() const {
+    std::uint64_t GetElementPosition() const {
       return ElementPosition;
     }
 
-    uint64 ElementSize(bool bWithDefault = false) const; /// return the size of the header+data, before writing
+    std::uint64_t ElementSize(bool bWithDefault = false) const; /// return the size of the header+data, before writing
 
     filepos_t Render(IOCallback & output, bool bWithDefault = false, bool bKeepPosition = false, bool bForceRender = false);
 
@@ -433,7 +433,7 @@ class EBML_DLL_API EbmlElement {
     virtual bool IsDummy() const {return false;}
     virtual bool IsMaster() const {return false;}
 
-    uint8 HeadSize() const {
+    std::uint8_t HeadSize() const {
       return EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
     } /// return the size of the head, on reading/writing
 
@@ -441,7 +441,7 @@ class EBML_DLL_API EbmlElement {
       \brief Force the size of an element
       \warning only possible if the size is "undefined"
     */
-    bool ForceSize(uint64 NewSize);
+    bool ForceSize(std::uint64_t NewSize);
 
     filepos_t OverwriteHead(IOCallback & output, bool bKeepPosition = false);
     filepos_t OverwriteData(IOCallback & output, bool bKeepPosition = false);
@@ -449,7 +449,7 @@ class EBML_DLL_API EbmlElement {
     /*!
       \brief void the content of the element (replace by EbmlVoid)
     */
-    uint64 VoidMe(IOCallback & output, bool bWithDefault = false);
+    std::uint64_t VoidMe(IOCallback & output, bool bWithDefault = false);
 
     bool DefaultISset() const {return DefaultIsSet;}
     void ForceNoDefault() {SetDefaultIsSet(false);}
@@ -459,11 +459,11 @@ class EBML_DLL_API EbmlElement {
     /*!
       \brief set the default size of an element
     */
-    virtual void SetDefaultSize(uint64 aDefaultSize) {DefaultSize = aDefaultSize;}
+    virtual void SetDefaultSize(std::uint64_t aDefaultSize) {DefaultSize = aDefaultSize;}
 
     bool ValueIsSet() const {return bValueIsSet;}
 
-    inline uint64 GetEndPosition() const {
+    inline std::uint64_t GetEndPosition() const {
       assert(bSizeIsFinite); // we don't know where the end is
       return SizePosition + CodedSizeLength(Size, SizeLength, bSizeIsFinite) + Size;
     }
@@ -488,22 +488,22 @@ class EBML_DLL_API EbmlElement {
     */
     EbmlElement(const EbmlElement & ElementToClone) = default;
 
-        inline uint64 GetDefaultSize() const {return DefaultSize;}
-        inline void SetSize_(uint64 aSize) {Size = aSize;}
+        inline std::uint64_t GetDefaultSize() const {return DefaultSize;}
+        inline void SetSize_(std::uint64_t aSize) {Size = aSize;}
         inline void SetValueIsSet(bool Set = true) {bValueIsSet = Set;}
         inline void SetDefaultIsSet(bool Set = true) {DefaultIsSet = Set;}
         inline void SetSizeIsFinite(bool Set = true) {bSizeIsFinite = Set;}
-        inline uint64 GetSizePosition() const {return SizePosition;}
+        inline std::uint64_t GetSizePosition() const {return SizePosition;}
 
 #if defined(EBML_STRICT_API)
   private:
 #endif
-    uint64 Size;        ///< the size of the data to write
-    uint64 DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
+    std::uint64_t Size;        ///< the size of the data to write
+    std::uint64_t DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
     int SizeLength; /// the minimum size on which the size will be written (0 = optimal)
     bool bSizeIsFinite;
-    uint64 ElementPosition;
-    uint64 SizePosition;
+    std::uint64_t ElementPosition;
+    std::uint64_t SizePosition;
     bool bValueIsSet;
     bool DefaultIsSet;
     bool bLocked;

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -32,7 +32,7 @@
     \file
     \version \$Id: EbmlEndian.h 1298 2008-02-21 22:14:18Z mosu $
     \author Ingo Ralf Blum   <ingoralfblum @ users.sf.net>
-    \author Lasse K‰rkk‰inen <tronic @ users.sf.net>
+    \author Lasse K√§rkk√§inen <tronic @ users.sf.net>
     \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 #ifndef LIBEBML_ENDIAN_H
@@ -83,7 +83,7 @@ template<class TYPE, endianess ENDIAN> class Endian
       inline operator const TYPE&() const { return platform_value; }
     //  inline TYPE endian() const   { return endian_value; }
       inline const TYPE &endian() const       { return endian_value; }
-      inline size_t size() const   { return sizeof(TYPE); }
+      inline std::size_t size() const   { return sizeof(TYPE); }
       inline bool operator!=(const binary *buffer) const {return *((TYPE*)buffer) == platform_value;}
 
 #if defined(EBML_STRICT_API)
@@ -102,7 +102,7 @@ template<class TYPE, endianess ENDIAN> class Endian
 #else  // _ENDIANESS_
           if (ENDIAN == big_endian)
 #endif // _ENDIANESS_
-            std::reverse(reinterpret_cast<uint8*>(&endian_value),reinterpret_cast<uint8*>(&endian_value+1));
+            std::reverse(reinterpret_cast<std::uint8_t*>(&endian_value),reinterpret_cast<std::uint8_t*>(&endian_value+1));
       }
 
       inline void process_platform()
@@ -113,7 +113,7 @@ template<class TYPE, endianess ENDIAN> class Endian
 #else  // _ENDIANESS_
           if (ENDIAN == big_endian)
 #endif // _ENDIANESS_
-            std::reverse(reinterpret_cast<uint8*>(&platform_value),reinterpret_cast<uint8*>(&platform_value+1));
+            std::reverse(reinterpret_cast<std::uint8_t*>(&platform_value),reinterpret_cast<std::uint8_t*>(&platform_value+1));
       }
 };
 

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -58,14 +58,13 @@ class EBML_DLL_API EbmlId {
       :Length(aLength)
     {
       Value = 0;
-      unsigned int i;
-      for (i=0; i<aLength; i++) {
+      for (unsigned int i=0; i<aLength; i++) {
         Value <<= 8;
         Value += aValue[i];
       }
     }
 
-    EbmlId(const uint32 aValue, const unsigned int aLength)
+    EbmlId(const std::uint32_t aValue, const unsigned int aLength)
       :Value(aValue), Length(aLength) {}
 
     inline bool operator==(const EbmlId & TestId) const
@@ -78,20 +77,19 @@ class EBML_DLL_API EbmlId {
     }
 
     inline void Fill(binary * Buffer) const {
-      unsigned int i;
-      for (i = 0; i<Length; i++) {
+      for (unsigned int i = 0; i<Length; i++) {
         Buffer[i] = (Value >> (8*(Length-i-1))) & 0xFF;
       }
     }
 
-        inline size_t GetLength() const { return Length; }
-        inline uint32 GetValue() const { return Value; }
+        inline std::size_t GetLength() const { return Length; }
+        inline std::uint32_t GetValue() const { return Value; }
 
 #if defined(EBML_STRICT_API)
     private:
 #endif
-    uint32 Value;
-    size_t Length;
+    std::uint32_t Value;
+    std::size_t Length;
 };
 
 END_LIBEBML_NAMESPACE

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -76,14 +76,14 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     bool SetSizeInfinite(bool aIsInfinite = true) {SetSizeIsFinite(!aIsInfinite); return true;}
 
     bool PushElement(EbmlElement & element);
-    uint64 GetSize() const {
+    std::uint64_t GetSize() const {
       if (IsFiniteSize())
                 return EbmlElement::GetSize();
       else
         return (0-1);
     }
 
-    uint64 GetDataStart() const {
+    std::uint64_t GetDataStart() const {
       return GetElementPosition() + EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(EbmlElement::GetSize(), GetSizeLength(), IsFiniteSize());
     }
 
@@ -107,7 +107,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     /*!
       \brief add an element at a specified location
     */
-    bool InsertElement(EbmlElement & element, size_t position = 0);
+    bool InsertElement(EbmlElement & element, std::size_t position = 0);
     bool InsertElement(EbmlElement & element, const EbmlElement & before);
 
     /*!
@@ -120,7 +120,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     */
     void Sort();
 
-    size_t ListSize() const {return ElementList.size();}
+    std::size_t ListSize() const {return ElementList.size();}
     std::vector<EbmlElement *> const &GetElementList() const {return ElementList;}
     std::vector<EbmlElement *> &GetElementList() {return ElementList;}
 
@@ -150,7 +150,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     /*!
       \brief Remove an element from the list of the master
     */
-    void Remove(size_t Index);
+    void Remove(std::size_t Index);
     void Remove(EBML_MASTER_ITERATOR & Itr);
     void Remove(EBML_MASTER_RITERATOR & Itr);
 
@@ -167,8 +167,8 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     void EnableChecksum(bool bIsEnabled = true) { bChecksumUsed = bIsEnabled; }
     bool HasChecksum() const {return bChecksumUsed;}
     bool VerifyChecksum() const;
-    uint32 GetCrc32() const {return Checksum.GetCrc32();}
-    void ForceChecksum(uint32 NewChecksum) {
+    std::uint32_t GetCrc32() const {return Checksum.GetCrc32();}
+    void ForceChecksum(std::uint32_t NewChecksum) {
       Checksum.ForceCrc32(NewChecksum);
       bChecksumUsed = true;
     }

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -54,15 +54,15 @@ const int DEFAULT_INT_SIZE = 1; ///< optimal size stored
 class EBML_DLL_API EbmlSInteger : public EbmlElement {
   public:
     EbmlSInteger();
-    EbmlSInteger(int64 DefaultValue);
+    EbmlSInteger(std::int64_t DefaultValue);
     EbmlSInteger(const EbmlSInteger & ElementToClone) = default;
 
-    EbmlSInteger & operator = (int64 NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
+    EbmlSInteger & operator = (std::int64_t NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
 
     /*!
       Set the default size of the integer (usually 1,2,4 or 8)
     */
-        virtual void SetDefaultSize(uint64 nDefaultSize = DEFAULT_INT_SIZE) {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
+        virtual void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_INT_SIZE) {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
     virtual bool ValidateSize() const {return IsFiniteSize() && (GetSize() <= 8);}
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false);
@@ -71,17 +71,17 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
 
     virtual bool IsSmallerThan(const EbmlElement *Cmp) const;
 
-    operator int8() const;
-    operator int16() const;
-    operator int32() const;
-    operator int64() const;
+    operator std::int8_t() const;
+    operator std::int16_t() const;
+    operator std::int32_t() const;
+    operator std::int64_t() const;
 
-    EbmlSInteger &SetValue(int64 NewValue);
-    int64 GetValue() const;
+    EbmlSInteger &SetValue(std::int64_t NewValue);
+    std::int64_t GetValue() const;
 
-    void SetDefaultValue(int64 aValue) {assert(!DefaultISset()); DefaultValue = aValue; SetDefaultIsSet();}
+    void SetDefaultValue(std::int64_t aValue) {assert(!DefaultISset()); DefaultValue = aValue; SetDefaultIsSet();}
 
-    int64 DefaultVal() const {assert(DefaultISset()); return DefaultValue;}
+    std::int64_t DefaultVal() const {assert(DefaultISset()); return DefaultValue;}
 
     bool IsDefaultValue() const {
       return (DefaultISset() && Value == DefaultValue);
@@ -92,8 +92,8 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
 #else
     protected:
 #endif
-    int64 Value; /// The actual value of the element
-    int64 DefaultValue;
+    std::int64_t Value; /// The actual value of the element
+    std::int64_t DefaultValue;
 };
 
 END_LIBEBML_NAMESPACE

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -56,9 +56,9 @@ class EBML_DLL_API EbmlStream {
       \param MaxDataSize The maximum possible of the data in the element (for sanity checks)
       \note the user will have to delete that element later
     */
-    EbmlElement * FindNextID(const EbmlCallbacks & ClassInfos, uint64 MaxDataSize);
+    EbmlElement * FindNextID(const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize);
 
-    EbmlElement * FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
+    EbmlElement * FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
 
     inline IOCallback & I_O() {return Stream;}
         operator IOCallback &() {return Stream;}

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -33,33 +33,30 @@
 #ifndef LIBEBML_TYPES_H
 #define LIBEBML_TYPES_H
 
+#include <cstdint>
+
 #include "ebml/c/libebml_t.h"
 #include "ebml/EbmlConfig.h"
 #include "EbmlEndian.h" // binary needs to be defined
 
 START_LIBEBML_NAMESPACE
 
-typedef wchar_t utf16;
-typedef uint32 utf32;
-typedef char utf8;
-
 typedef binary bits80[10];
 
-typedef Endian<int16,little_endian>  lil_int16;
-typedef Endian<int32,little_endian>  lil_int32;
-typedef Endian<int64,little_endian>  lil_int64;
-typedef Endian<uint16,little_endian> lil_uint16;
-typedef Endian<uint32,little_endian> lil_uint32;
-typedef Endian<uint64,little_endian> lil_uint64;
-typedef Endian<int16,big_endian>     big_int16;
-typedef Endian<int32,big_endian>     big_int32;
-typedef Endian<int64,big_endian>     big_int64;
-typedef Endian<uint16,big_endian>    big_uint16;
-typedef Endian<uint32,big_endian>    big_uint32;
-typedef Endian<uint64,big_endian>    big_uint64;
-typedef Endian<uint32,big_endian>    checksum;
-typedef Endian<bits80,big_endian>    big_80bits;
-
+using lil_int16 = Endian<std::int16_t,little_endian>;
+using lil_int32 = Endian<std::int32_t,little_endian>;
+using lil_int64 = Endian<std::int64_t,little_endian>;
+using lil_uint16 = Endian<std::uint16_t,little_endian>;
+using lil_uint32 = Endian<std::uint32_t,little_endian>;
+using lil_uint64 = Endian<std::uint64_t,little_endian>;
+using big_int16 = Endian<std::int16_t,big_endian>;
+using big_int32 = Endian<std::int32_t,big_endian>;
+using big_int64 = Endian<std::int64_t,big_endian>;
+using big_uint16 = Endian<std::uint16_t,big_endian>;
+using big_uint32 = Endian<std::uint32_t,big_endian>;
+using big_uint64 = Endian<std::uint64_t,big_endian>;
+using checksum = Endian<std::uint32_t,big_endian>;
+using big_80bits = Endian<bits80,big_endian>;
 
 enum ScopeMode {
   SCOPE_PARTIAL_DATA = 0,

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -52,15 +52,15 @@ const int DEFAULT_UINT_SIZE = 0; ///< optimal size stored
 class EBML_DLL_API EbmlUInteger : public EbmlElement {
   public:
     EbmlUInteger();
-    EbmlUInteger(uint64 DefaultValue);
+    EbmlUInteger(std::uint64_t DefaultValue);
     EbmlUInteger(const EbmlUInteger & ElementToClone) = default;
 
-    EbmlUInteger & operator=(uint64 NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
+    EbmlUInteger & operator=(std::uint64_t NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
 
     /*!
       Set the default size of the integer (usually 1,2,4 or 8)
     */
-    virtual void SetDefaultSize(uint64 nDefaultSize = DEFAULT_UINT_SIZE) {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
+    virtual void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_UINT_SIZE) {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
     virtual bool ValidateSize() const {return IsFiniteSize() && (GetSize() <= 8);}
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false);
@@ -69,17 +69,17 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
 
     virtual bool IsSmallerThan(const EbmlElement *Cmp) const;
 
-    operator uint8()  const;
-    operator uint16() const;
-    operator uint32() const;
-    operator uint64() const;
+    operator std::uint8_t()  const;
+    operator std::uint16_t() const;
+    operator std::uint32_t() const;
+    operator std::uint64_t() const;
 
-    EbmlUInteger &SetValue(uint64 NewValue);
-    uint64 GetValue() const;
+    EbmlUInteger &SetValue(std::uint64_t NewValue);
+    std::uint64_t GetValue() const;
 
-    void SetDefaultValue(uint64);
+    void SetDefaultValue(std::uint64_t);
 
-    uint64 DefaultVal() const;
+    std::uint64_t DefaultVal() const;
 
     bool IsDefaultValue() const {
       return (DefaultISset() && Value == DefaultValue);
@@ -90,8 +90,8 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
 #else
     protected:
 #endif
-    uint64 Value; /// The actual value of the element
-    uint64 DefaultValue;
+    std::uint64_t Value; /// The actual value of the element
+    std::uint64_t DefaultValue;
 };
 
 END_LIBEBML_NAMESPACE

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -70,7 +70,7 @@ public:
   UTFstring & operator=(wchar_t);
 
   /// Return length of string
-  size_t length() const {return _Length;}
+  std::size_t length() const {return _Length;}
 
   operator const wchar_t*() const;
   const wchar_t* c_str() const {return _Data;}
@@ -83,7 +83,7 @@ public:
 #else
     protected:
 #endif
-  size_t _Length; ///< length of the UCS string excluding the \0
+  std::size_t _Length; ///< length of the UCS string excluding the \0
   wchar_t* _Data; ///< internal UCS representation
   std::string UTF8string;
   static bool wcscmp_internal(const wchar_t *str1, const wchar_t *str2);

--- a/ebml/EbmlVoid.h
+++ b/ebml/EbmlVoid.h
@@ -48,7 +48,7 @@ DECLARE_EBML_BINARY(EbmlVoid)
     /*!
       \brief Set the size of the data (not the complete size of the element)
     */
-    void SetSize(uint64 aSize) {SetSize_(aSize);}
+    void SetSize(std::uint64_t aSize) {SetSize_(aSize);}
 
     /*!
       \note overwrite to write fake data
@@ -58,12 +58,12 @@ DECLARE_EBML_BINARY(EbmlVoid)
     /*!
       \brief Replace the void element content (written) with this one
     */
-    uint64 ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
+    std::uint64_t ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
 
     /*!
       \brief Void the content of an element
     */
-    uint64 Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
+    std::uint64_t Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
 
         EBML_CONCRETE_CLASS(EbmlVoid)
 };

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -59,22 +59,22 @@ public:
   // file, the buffer and the size and the function returns the bytes read.
   // If an error occurs or the file pointer points to the end of the file 0 is returned.
   // Users are encouraged to throw a descriptive exception, when an error occurs.
-  virtual uint32 read(void*Buffer,size_t Size)=0;
+  virtual std::uint32_t read(void*Buffer,std::size_t Size)=0;
 
   // Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
   // or SEEK_END. The callback should return true(1) if the seek operation succeeded
   // or false (0), when the seek fails.
-  virtual void setFilePointer(int64 Offset,seek_mode Mode=seek_beginning)=0;
+  virtual void setFilePointer(std::int64_t Offset,seek_mode Mode=seek_beginning)=0;
 
   // This callback just works like its read pendant. It returns the number of bytes written.
-  virtual size_t write(const void*Buffer,size_t Size)=0;
+  virtual std::size_t write(const void*Buffer,std::size_t Size)=0;
 
   // Although the position is always positive, the return value of this callback is signed to
   // easily allow negative values for returning errors. When an error occurs, the implementor
   // should return -1 and the file pointer otherwise.
   //
   // If an error occurs, an exception should be thrown.
-  virtual uint64 getFilePointer()=0;
+  virtual std::uint64_t getFilePointer()=0;
 
   // The close callback flushes the file buffers to disk and closes the file. When using the stdio
   // library, this is equivalent to calling fclose. When the close is not successful, an exception
@@ -85,11 +85,11 @@ public:
   // The readFully is made virtual to allow derived classes to use another
   // implementation for this method, which e.g. does not read any data
   // unlike this does
-  void readFully(void*Buffer,size_t Size);
+  void readFully(void*Buffer,std::size_t Size);
 
   template<class STRUCT> void readStruct(STRUCT&Struct){readFully(&Struct,sizeof(Struct));}
 
-  void writeFully(const void*Buffer,size_t Size);
+  void writeFully(const void*Buffer,std::size_t Size);
 
   template<class STRUCT> void writeStruct(const STRUCT&Struct){writeFully(&Struct,sizeof(Struct));}
 };

--- a/ebml/MemIOCallback.h
+++ b/ebml/MemIOCallback.h
@@ -48,25 +48,25 @@ START_LIBEBML_NAMESPACE
 class EBML_DLL_API MemIOCallback : public IOCallback
 {
 public:
-  MemIOCallback(uint64 DefaultSize = 128);
+  MemIOCallback(std::uint64_t DefaultSize = 128);
   ~MemIOCallback();
 
   /*!
     Use this to copy some data to the Buffer from this classes data
   */
-  uint32 read(void *Buffer, size_t Size);
+  std::uint32_t read(void *Buffer, std::size_t Size);
 
   /*!
     Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
     or SEEK_END. The callback should return true(1) if the seek operation succeeded
     or false (0), when the seek fails.
   */
-  void setFilePointer(int64 Offset, seek_mode Mode=seek_beginning);
+  void setFilePointer(std::int64_t Offset, seek_mode Mode=seek_beginning);
 
   /*!
     This callback just works like its read pendant. It returns the number of bytes written.
   */
-  size_t write(const void *Buffer, size_t Size);
+  std::size_t write(const void *Buffer, std::size_t Size);
 
   /*!
     Although the position is always positive, the return value of this callback is signed to
@@ -75,7 +75,7 @@ public:
 
     If an error occurs, an exception should be thrown.
   */
-  virtual uint64 getFilePointer() {return dataBufferPos;}
+  virtual std::uint64_t getFilePointer() {return dataBufferPos;}
 
   /*!
     The close callback flushes the file buffers to disk and closes the file. When using the stdio
@@ -85,12 +85,12 @@ public:
   void close() {}
 
   binary *GetDataBuffer() const {return dataBuffer;}
-  uint64 GetDataBufferSize() const {return dataBufferTotalSize;}
-  void SetDataBufferSize(uint64 newDataBufferSize) {dataBufferTotalSize = newDataBufferSize;}
+  std::uint64_t GetDataBufferSize() const {return dataBufferTotalSize;}
+  void SetDataBufferSize(std::uint64_t newDataBufferSize) {dataBufferTotalSize = newDataBufferSize;}
   /*!
     Use this to write some data from another IOCallback
   */
-  uint32 write(IOCallback & IOToRead, size_t Size);
+  std::uint32_t write(IOCallback & IOToRead, std::size_t Size);
 
   bool IsOk() { return mOk; }
   const std::string &GetLastErrorStr() { return mLastErrorStr; }
@@ -102,15 +102,15 @@ protected:
   /*!
     Postion where we start 'writing' to the dataBuffer
   */
-  uint64 dataBufferPos;
+  std::uint64_t dataBufferPos;
   /*!
     Size of the data in the dataBuffer
   */
-  uint64 dataBufferTotalSize;
+  std::uint64_t dataBufferTotalSize;
   /*!
     Size of the memory malloc()/realloc()
   */
-  uint64 dataBufferMemorySize;
+  std::uint64_t dataBufferMemorySize;
 };
 
 END_LIBEBML_NAMESPACE

--- a/ebml/MemReadIOCallback.h
+++ b/ebml/MemReadIOCallback.h
@@ -40,24 +40,24 @@ START_LIBEBML_NAMESPACE
 
 class EBML_DLL_API MemReadIOCallback : public IOCallback {
 protected:
-  uint8 const *mStart, *mEnd, *mPtr;
+  std::uint8_t const *mStart, *mEnd, *mPtr;
 
 public:
-  MemReadIOCallback(void const *Ptr, size_t Size);
+  MemReadIOCallback(void const *Ptr, std::size_t Size);
   MemReadIOCallback(EbmlBinary const &Binary);
   MemReadIOCallback(MemReadIOCallback const &Mem);
   virtual ~MemReadIOCallback() = default;
 
-  uint32 read(void *Buffer, size_t Size);
-  void setFilePointer(int64 Offset, seek_mode Mode = seek_beginning);
-  size_t write(void const *, size_t) { return 0; }
-  virtual uint64 getFilePointer() { return mPtr - mStart; }
+  std::uint32_t read(void *Buffer, std::size_t Size);
+  void setFilePointer(std::int64_t Offset, seek_mode Mode = seek_beginning);
+  std::size_t write(void const *, std::size_t) { return 0; }
+  virtual std::uint64_t getFilePointer() { return mPtr - mStart; }
   void close() {}
   binary const *GetDataBuffer() const { return mPtr; }
-  uint64 GetDataBufferSize() const { return mEnd - mStart; }
+  std::uint64_t GetDataBufferSize() const { return mEnd - mStart; }
 
 protected:
-  void Init(void const *Ptr, size_t Size);
+  void Init(void const *Ptr, std::size_t Size);
 };
 
 END_LIBEBML_NAMESPACE

--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -46,37 +46,37 @@ class EBML_DLL_API SafeReadIOCallback {
 public:
   class EBML_DLL_API EndOfStreamX {
   public:
-    size_t mMissingBytes;
+    std::size_t mMissingBytes;
     EndOfStreamX(std::size_t MissingBytes);
   };
 
 private:
   IOCallback *mIO;
   bool mDeleteIO;
-  size_t mSize;
+  std::size_t mSize;
 
 public:
   SafeReadIOCallback(IOCallback *IO, bool DeleteIO);
-  SafeReadIOCallback(void const *Mem, size_t Size);
+  SafeReadIOCallback(void const *Mem, std::size_t Size);
   SafeReadIOCallback(EbmlBinary const &Binary);
   ~SafeReadIOCallback();
 
-  size_t GetPosition() const;
-  size_t GetSize() const;
-  size_t GetRemainingBytes() const;
+  std::size_t GetPosition() const;
+  std::size_t GetSize() const;
+  std::size_t GetRemainingBytes() const;
   bool IsEmpty() const;
 
-  uint8  GetUInt8();
-  uint64 GetUIntBE(size_t NumBytes);
-  uint16 GetUInt16BE();
-  uint32 GetUInt24BE();
-  uint32 GetUInt32BE();
-  uint64 GetUInt64BE();
+  std::uint8_t  GetUInt8();
+  std::uint64_t GetUIntBE(std::size_t NumBytes);
+  std::uint16_t GetUInt16BE();
+  std::uint32_t GetUInt24BE();
+  std::uint32_t GetUInt32BE();
+  std::uint64_t GetUInt64BE();
 
-  void Read(void *Dst, size_t Count);
+  void Read(void *Dst, std::size_t Count);
 
-  void Skip(size_t Count);
-  void Seek(size_t Position);
+  void Skip(std::size_t Count);
+  void Seek(std::size_t Position);
 
 private:
   SafeReadIOCallback(SafeReadIOCallback const &) { }

--- a/ebml/StdIOCallback.h
+++ b/ebml/StdIOCallback.h
@@ -66,29 +66,29 @@ class EBML_DLL_API StdIOCallback:public IOCallback
 {
     private:
       FILE*File;
-    uint64 mCurrentPosition;
+    std::uint64_t mCurrentPosition;
 
     public:
 //  StdIOCallback(const char*Path,const char*Mode);
   StdIOCallback(const char*Path, const open_mode Mode);
   virtual ~StdIOCallback() noexcept;
 
-  virtual uint32 read(void*Buffer,size_t Size);
+  virtual std::uint32_t read(void*Buffer,std::size_t Size);
 
   // Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
   // or SEEK_END. The callback should return true(1) if the seek operation succeeded
   // or false (0), when the seek fails.
-  virtual void setFilePointer(int64 Offset,seek_mode Mode=seek_beginning);
+  virtual void setFilePointer(std::int64_t Offset,seek_mode Mode=seek_beginning);
 
   // This callback just works like its read pendant. It returns the number of bytes written.
-  virtual size_t write(const void*Buffer,size_t Size);
+  virtual std::size_t write(const void*Buffer,std::size_t Size);
 
   // Although the position is always positive, the return value of this callback is signed to
   // easily allow negative values for returning errors. When an error occurs, the implementor
   // should return -1 and the file pointer otherwise.
   //
   // If an error occurs, an exception should be thrown.
-  virtual uint64 getFilePointer();
+  virtual std::uint64_t getFilePointer();
 
   // The close callback flushes the file buffers to disk and closes the file. When using the stdio
   // library, this is equivalent to calling fclose. When the close is not successful, an exception

--- a/ebml/c/libebml_t.h
+++ b/ebml/c/libebml_t.h
@@ -48,81 +48,15 @@
 extern "C" {
 #endif
 
-// Changed char is unsigned now (signedness was causing trouble in endil)
-#if defined(_WIN32)
-# if !defined(__GNUC__)    // Microsoft Visual C++
-    typedef signed __int64 int64;
-    typedef signed __int32 int32;
-    typedef signed __int16 int16;
-    typedef signed __int8 int8;
-    typedef __int8 character;
-    typedef unsigned __int64 uint64;
-    typedef unsigned __int32 uint32;
-    typedef unsigned __int16 uint16;
-    typedef unsigned __int8 uint8;
-# else // __GNUC__, this is mingw
-#  include <stdint.h>
-    typedef int64_t int64;
-    typedef int32_t int32;
-    typedef int16_t int16;
-    typedef int8_t int8;
-    typedef int8_t character;
-    typedef uint64_t uint64;
-    typedef uint32_t uint32;
-    typedef uint16_t uint16;
-    typedef uint8_t uint8;
-# endif // __GNUC__
-#elif defined(__BEOS__) || defined(__HAIKU__)
-#include <SupportDefs.h>
-#elif defined(DJGPP)        /* SL : DJGPP doesn't support POSIX types ???? */
-    typedef signed long long int64;
-    typedef signed long int32;
-    typedef signed short int16;
-    typedef signed char int8;
-    typedef char character;
-    typedef unsigned long long uint64;
-    typedef unsigned long uint32;
-    typedef unsigned short uint16;
-    typedef unsigned char uint8;
-#elif defined(__sun) && (defined(__svr4__) || defined(__SVR4)) // SOLARIS
-# include <inttypes.h>
-# ifdef _NO_LONGLONG
-#  error This compiler does not support 64bit integers.
-# endif
-    typedef int64_t int64;
-    typedef int32_t int32;
-    typedef int16_t int16;
-    typedef int8_t int8;
-    typedef int8_t character;
-    typedef uint64_t uint64;
-    typedef uint32_t uint32;
-    typedef uint16_t uint16;
-    typedef uint8_t uint8;
-#elif defined(__BEOS__) || defined(__HAIKU__)
-# include <support/SupportDefs.h>
-#else // anything else (Linux, BSD, ...)
-# include <inttypes.h>
-# include <sys/types.h>
-    typedef int64_t int64;
-    typedef int32_t int32;
-    typedef int16_t int16;
-    typedef int8_t int8;
-    typedef int8_t character;
-    typedef uint64_t uint64;
-    typedef uint32_t uint32;
-    typedef uint16_t uint16;
-    typedef uint8_t uint8;
-#endif /* anything else */
+using binary = std::uint8_t;
+using filepos_t = std::uint64_t;
 
-typedef uint8  binary;
-typedef uint64 filepos_t;
-
-typedef enum open_mode {
+enum open_mode {
     MODE_READ,
     MODE_WRITE,
     MODE_CREATE,
     MODE_SAFE
-} open_mode;
+};
 
 #define EBML_MIN(x,y) ((x)<(y) ? (x) : (y))
 

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -76,7 +76,7 @@ filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, b
 /*!
   \note no Default binary value handled
 */
-uint64 EbmlBinary::UpdateSize(bool /* bWithDefault */, bool /* bForceRender */)
+std::uint64_t EbmlBinary::UpdateSize(bool /* bWithDefault */, bool /* bForceRender */)
 {
   return GetSize();
 }

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -39,20 +39,20 @@
 #include "ebml/MemIOCallback.h"
 
 #ifdef WORDS_BIGENDIAN
-static constexpr uint32_t CRC32_INDEX(uint32_t c) { return c >> 24; }
-static constexpr uint32_t CRC32_SHIFTED(uint32_t c) { return c << 8; }
+static constexpr std::uint32_t CRC32_INDEX(std::uint32_t c) { return c >> 24; }
+static constexpr std::uint32_t CRC32_SHIFTED(std::uint32_t c) { return c << 8; }
 #else
-static constexpr uint32_t CRC32_INDEX(uint32_t c) { return c & 0xFF; }
-static constexpr uint32_t CRC32_SHIFTED(uint32_t c) { return c >> 8; }
+static constexpr std::uint32_t CRC32_INDEX(std::uint32_t c) { return c & 0xFF; }
+static constexpr std::uint32_t CRC32_SHIFTED(std::uint32_t c) { return c >> 8; }
 #endif
 
-static constexpr uint32 CRC32_NEGL = 0xffffffffL;
+static constexpr std::uint32_t CRC32_NEGL = 0xffffffffL;
 
 START_LIBEBML_NAMESPACE
 
 DEFINE_EBML_CLASS_GLOBAL(EbmlCrc32, 0xBF, 1, "EBMLCrc32\0ratamadabapa")
 
-const uint32 EbmlCrc32::m_tab[] = {
+const std::uint32_t EbmlCrc32::m_tab[] = {
 #ifdef WORDS_BIGENDIAN
   0x00000000L, 0x96300777L, 0x2c610eeeL, 0xba510999L, 0x19c46d07L,
   0x8ff46a70L, 0x35a563e9L, 0xa395649eL, 0x3288db0eL, 0xa4b8dc79L,
@@ -247,15 +247,15 @@ filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
   return GetSize();
 }
 
-bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
+bool EbmlCrc32::CheckCRC(std::uint32_t inputCRC, const binary *input, std::uint32_t length)
 {
-  uint32 crc = CRC32_NEGL;
+  std::uint32_t crc = CRC32_NEGL;
 
-  for(; !IsAligned<uint32>(input) && length > 0; length--)
+  for(; !IsAligned<std::uint32_t>(input) && length > 0; length--)
     crc = m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
 
   while (length >= 4) {
-    crc ^= *reinterpret_cast<const uint32 *>(input);
+    crc ^= *reinterpret_cast<const std::uint32_t *>(input);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
@@ -273,20 +273,20 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
   return crc == inputCRC;
 }
 
-void EbmlCrc32::FillCRC32(const binary *input, uint32 length)
+void EbmlCrc32::FillCRC32(const binary *input, std::uint32_t length)
 {
   ResetCRC();
   Update(input, length);
   Finalize();
 
-  /*uint32 crc = CRC32_NEGL;
+  /*std::uint32_t crc = CRC32_NEGL;
 
-  for(; !IsAligned<uint32>(s) && n > 0; n--)
+  for(; !IsAligned<std::uint32_t>(s) && n > 0; n--)
     crc = m_tab[CRC32_INDEX(crc) ^ *s++] ^ CRC32_SHIFTED(crc);
 
   while (n >= 4)
   {
-    crc ^= *(const uint32 *)s;
+    crc ^= *(const std::uint32_t *)s;
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
@@ -307,15 +307,15 @@ void EbmlCrc32::FillCRC32(const binary *input, uint32 length)
 
 }
 
-void EbmlCrc32::Update(const binary *input, uint32 length)
+void EbmlCrc32::Update(const binary *input, std::uint32_t length)
 {
-  uint32 crc = m_crc;
+  std::uint32_t crc = m_crc;
 
-  for(; !IsAligned<uint32>(input) && length > 0; length--)
+  for(; !IsAligned<std::uint32_t>(input) && length > 0; length--)
     crc = m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
 
   while (length >= 4) {
-    crc ^= *reinterpret_cast<const uint32 *>(input);
+    crc ^= *reinterpret_cast<const std::uint32_t *>(input);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -37,7 +37,7 @@
 
 START_LIBEBML_NAMESPACE
 
-const uint64 EbmlDate::UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
+const std::uint64_t EbmlDate::UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
 
 EbmlDate::EbmlDate(const EbmlDate & ElementToClone)
 :EbmlElement(ElementToClone)

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -91,7 +91,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, bo
     output.writeFully(&TmpToWrite.endian(), GetSize());
   } else if (GetSize() == 8) {
     double val = Value;
-    int64 Tmp;
+    std::int64_t Tmp;
     memcpy(&Tmp, &val, 8);
     big_int64 TmpToWrite(Tmp);
     output.writeFully(&TmpToWrite.endian(), GetSize());
@@ -100,7 +100,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, bo
   return GetSize();
 }
 
-uint64 EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
+std::uint64_t EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
 {
   if (!bWithDefault && IsDefaultValue())
     return 0;
@@ -128,7 +128,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
   if (GetSize() == 4) {
     big_int32 TmpRead;
     TmpRead.Eval(Buffer);
-    auto tmpp = int32(TmpRead);
+    auto tmpp = std::int32_t(TmpRead);
     float val;
     memcpy(&val, &tmpp, 4);
     Value = static_cast<double>(val);
@@ -136,7 +136,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
   } else {
     big_int64 TmpRead;
     TmpRead.Eval(Buffer);
-    auto tmpp = int64(TmpRead);
+    auto tmpp = std::int64_t(TmpRead);
     double val;
     memcpy(&val, &tmpp, 8);
     Value = val;

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -124,7 +124,7 @@ bool EbmlMaster::PushElement(EbmlElement & element)
   return true;
 }
 
-uint64 EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)
+std::uint64_t EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)
 {
   SetSize_(0);
 
@@ -139,9 +139,9 @@ uint64 EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)
     if (!bWithDefault && Element->IsDefaultValue())
       continue;
     Element->UpdateSize(bWithDefault, bForceRender);
-    uint64 SizeToAdd = Element->ElementSize(bWithDefault);
+    std::uint64_t SizeToAdd = Element->ElementSize(bWithDefault);
 #if defined(LIBEBML_DEBUG)
-    if (static_cast<int64>(SizeToAdd) == (0-1))
+    if (static_cast<std::int64_t>(SizeToAdd) == (0-1))
       return (0-1);
 #endif // LIBEBML_DEBUG
     SetSize_(GetSize() + SizeToAdd);
@@ -304,7 +304,7 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
 */
 EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt, bool bCreateIfNull)
 {
-  size_t Index;
+  std::size_t Index;
 
   for (Index = 0; Index < ElementList.size(); Index++) {
     if ((ElementList[Index]) == &PastElt) {
@@ -341,7 +341,7 @@ EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt, bool bCreateIf
 
 EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt) const
 {
-  size_t Index;
+  std::size_t Index;
 
   for (Index = 0; Index < ElementList.size(); Index++) {
     if ((ElementList[Index]) == &PastElt) {
@@ -397,7 +397,7 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
     }
   }
   ElementList.clear();
-  uint64 MaxSizeToRead;
+  std::uint64_t MaxSizeToRead;
 
   if (IsFiniteSize())
     MaxSizeToRead = GetSize();
@@ -508,7 +508,7 @@ processCrc:
   SetValueIsSet();
 }
 
-void EbmlMaster::Remove(size_t Index)
+void EbmlMaster::Remove(std::size_t Index)
 {
   if (Index < ElementList.size()) {
     auto Itr = ElementList.begin();
@@ -546,7 +546,7 @@ bool EbmlMaster::VerifyChecksum() const
   return (aChecksum.GetCrc32() == Checksum.GetCrc32());
 }
 
-bool EbmlMaster::InsertElement(EbmlElement & element, size_t position)
+bool EbmlMaster::InsertElement(EbmlElement & element, std::size_t position)
 {
   auto Itr = ElementList.begin();
   while (Itr != ElementList.end() && position--)

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -43,12 +43,12 @@
 
 namespace {
 
-int64
-ToSigned(uint64 u) {
-  if (u <= static_cast<uint64>(std::numeric_limits<int64>::max()))
-    return static_cast<int64>(u);
+std::int64_t
+ToSigned(std::uint64_t u) {
+  if (u <= static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
+    return static_cast<std::int64_t>(u);
 
-  return static_cast<int64>(u - std::numeric_limits<int64>::min()) + std::numeric_limits<int64>::min();
+  return static_cast<std::int64_t>(u - std::numeric_limits<std::int64_t>::min()) + std::numeric_limits<std::int64_t>::min();
 }
 
 } // namespace
@@ -59,20 +59,20 @@ EbmlSInteger::EbmlSInteger()
   :EbmlElement(DEFAULT_INT_SIZE, false)
 {}
 
-EbmlSInteger::EbmlSInteger(int64 aDefaultValue)
+EbmlSInteger::EbmlSInteger(std::int64_t aDefaultValue)
   :EbmlElement(DEFAULT_INT_SIZE, true), Value(aDefaultValue)
 {
   SetDefaultIsSet();
 }
 
-EbmlSInteger::operator int8() const {return  int8(Value);}
-EbmlSInteger::operator int16() const {return int16(Value);}
-EbmlSInteger::operator int32() const {return int32(Value);}
-EbmlSInteger::operator int64() const {return Value;}
+EbmlSInteger::operator std::int8_t() const {return  std::int8_t(Value);}
+EbmlSInteger::operator std::int16_t() const {return std::int16_t(Value);}
+EbmlSInteger::operator std::int32_t() const {return std::int32_t(Value);}
+EbmlSInteger::operator std::int64_t() const {return Value;}
 
-int64 EbmlSInteger::GetValue() const {return Value;}
+std::int64_t EbmlSInteger::GetValue() const {return Value;}
 
-EbmlSInteger & EbmlSInteger::SetValue(int64 NewValue) {
+EbmlSInteger & EbmlSInteger::SetValue(std::int64_t NewValue) {
   return *this = NewValue;
 }
 
@@ -87,7 +87,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   if (GetSizeLength() > 8)
     return 0; // integer bigger coded on more than 64 bits are not supported
 
-  int64 TempValue = Value;
+  std::int64_t TempValue = Value;
   for (i=0; i<GetSize();i++) {
     FinalData[GetSize()-i-1] = binary(TempValue & 0xFF);
     TempValue >>= 8;
@@ -98,7 +98,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-uint64 EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 {
   if (!bWithDefault && IsDefaultValue())
     return 0;
@@ -145,7 +145,7 @@ filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
   binary Buffer[8];
   input.readFully(Buffer, GetSize());
 
-  uint64 TempValue = Buffer[0] & 0x80 ? std::numeric_limits<uint64>::max() : 0;
+  std::uint64_t TempValue = Buffer[0] & 0x80 ? std::numeric_limits<std::uint64_t>::max() : 0;
 
   for (unsigned int i=0; i<GetSize(); i++) {
     TempValue <<= 8;

--- a/src/EbmlStream.cpp
+++ b/src/EbmlStream.cpp
@@ -41,12 +41,12 @@ EbmlStream::EbmlStream(IOCallback & DataStream)
   :Stream(DataStream)
 {}
 
-EbmlElement * EbmlStream::FindNextID(const EbmlCallbacks & ClassInfos, uint64 MaxDataSize)
+EbmlElement * EbmlStream::FindNextID(const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize)
 {
   return EbmlElement::FindNextID(Stream, ClassInfos, MaxDataSize);
 }
 
-EbmlElement * EbmlStream::FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel)
+EbmlElement * EbmlStream::FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel)
 {
   return EbmlElement::FindNextElement(Stream, Context, UpperLevel, MaxDataSize, AllowDummyElt, MaxLowerLevel);
 }

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -123,7 +123,7 @@ std::string EbmlString::GetValue() const {
   return Value;
 }
 
-uint64 EbmlString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 {
   if (!bWithDefault && IsDefaultValue())
     return 0;

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -44,33 +44,33 @@ EbmlUInteger::EbmlUInteger()
   :EbmlElement(DEFAULT_UINT_SIZE, false)
 {}
 
-EbmlUInteger::EbmlUInteger(uint64 aDefaultValue)
+EbmlUInteger::EbmlUInteger(std::uint64_t aDefaultValue)
   :EbmlElement(DEFAULT_UINT_SIZE, true), Value(aDefaultValue), DefaultValue(aDefaultValue)
 {
   SetDefaultIsSet();
 }
 
-void EbmlUInteger::SetDefaultValue(uint64 aValue)
+void EbmlUInteger::SetDefaultValue(std::uint64_t aValue)
 {
   assert(!DefaultISset());
   DefaultValue = aValue;
   SetDefaultIsSet();
 }
 
-uint64 EbmlUInteger::DefaultVal() const
+std::uint64_t EbmlUInteger::DefaultVal() const
 {
   assert(DefaultISset());
   return DefaultValue;
 }
 
-EbmlUInteger::operator uint8()  const {return uint8(Value); }
-EbmlUInteger::operator uint16() const {return uint16(Value);}
-EbmlUInteger::operator uint32() const {return uint32(Value);}
-EbmlUInteger::operator uint64() const {return Value;}
+EbmlUInteger::operator std::uint8_t()  const {return std::uint8_t(Value); }
+EbmlUInteger::operator std::uint16_t() const {return std::uint16_t(Value);}
+EbmlUInteger::operator std::uint32_t() const {return std::uint32_t(Value);}
+EbmlUInteger::operator std::uint64_t() const {return Value;}
 
-uint64 EbmlUInteger::GetValue() const {return Value;}
+std::uint64_t EbmlUInteger::GetValue() const {return Value;}
 
-EbmlUInteger & EbmlUInteger::SetValue(uint64 NewValue) {
+EbmlUInteger & EbmlUInteger::SetValue(std::uint64_t NewValue) {
   return *this = NewValue;
 }
 
@@ -84,7 +84,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   if (GetSizeLength() > 8)
     return 0; // integer bigger coded on more than 64 bits are not supported
 
-  uint64 TempValue = Value;
+  std::uint64_t TempValue = Value;
   for (unsigned int i=0; i<GetSize();i++) {
     FinalData[GetSize()-i-1] = TempValue & 0xFF;
     TempValue >>= 8;
@@ -95,7 +95,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-uint64 EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 {
   if (!bWithDefault && IsDefaultValue())
     return 0;

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -96,7 +96,7 @@ UTFstring & UTFstring::operator=(const wchar_t * _aBuf)
     return *this;
   }
 
-  size_t aLen;
+  std::size_t aLen;
   for (aLen=0; _aBuf[aLen] != 0; aLen++);
   _Length = aLen;
   _Data = new wchar_t[_Length+1];
@@ -173,7 +173,7 @@ void UTFstring::UpdateFromUCS2()
     return;
 
   // Only convert up to the first \0 character if present.
-  size_t Current = 0;
+  std::size_t Current = 0;
   while ((Current < _Length) && _Data[Current])
     ++Current;
 
@@ -193,7 +193,7 @@ void UTFstring::UpdateFromUCS2()
 
 bool UTFstring::wcscmp_internal(const wchar_t *str1, const wchar_t *str2)
 {
-  size_t Index=0;
+  std::size_t Index=0;
   while (str1[Index] == str2[Index] && str1[Index] != 0) {
     Index++;
   }
@@ -235,7 +235,7 @@ const UTFstring & EbmlUnicodeString::DefaultVal() const
 */
 filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
 {
-  uint32 Result = Value.GetUTF8().length();
+  std::uint32_t Result = Value.GetUTF8().length();
 
   if (Result != 0) {
     output.writeFully(Value.GetUTF8().c_str(), Result);
@@ -286,7 +286,7 @@ std::string EbmlUnicodeString::GetValueUTF8() const {
 /*!
 \note limited to UCS-2
 */
-uint64 EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
 {
   if (!bWithDefault && IsDefaultValue())
     return 0;

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -50,7 +50,7 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, boo
   // write dummy data by 4KB chunks
   static binary DummyBuf[4*1024];
 
-  uint64 SizeToWrite = GetSize();
+  std::uint64_t SizeToWrite = GetSize();
   while (SizeToWrite > 4*1024) {
     output.writeFully(DummyBuf, 4*1024);
     SizeToWrite -= 4*1024;
@@ -59,7 +59,7 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, boo
   return GetSize();
 }
 
-uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
+std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
 {
   EltToReplaceWith.UpdateSize(bWithDefault);
   if (HeadSize() + GetSize() < EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize()) {
@@ -71,7 +71,7 @@ uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output
     return INVALID_FILEPOS_T;
   }
 
-  uint64 CurrentPosition = output.getFilePointer();
+  std::uint64_t CurrentPosition = output.getFilePointer();
 
   output.setFilePointer(GetElementPosition());
   EltToReplaceWith.Render(output, bWithDefault);
@@ -96,7 +96,7 @@ uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output
   return GetSize() + HeadSize();
 }
 
-uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
+std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
 {
   //  EltToVoid.UpdateSize(bWithDefault);
   if (EltToVoid.GetElementPosition() == 0) {
@@ -108,7 +108,7 @@ uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, b
     return 0;
   }
 
-  uint64 CurrentPosition = output.getFilePointer();
+  std::uint64_t CurrentPosition = output.getFilePointer();
 
   output.setFilePointer(EltToVoid.GetElementPosition());
 
@@ -116,8 +116,8 @@ uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, b
   SetSize(EltToVoid.GetSize() + EltToVoid.HeadSize() - 1); // 1 for the ID
   SetSize(GetSize() - CodedSizeLength(GetSize(), GetSizeLength(), IsFiniteSize()));
   // make sure we handle even the strange cases
-  //uint32 A1 = GetSize() + HeadSize();
-  //uint32 A2 = EltToVoid.GetSize() + EltToVoid.HeadSize();
+  //std::uint32_t A1 = GetSize() + HeadSize();
+  //std::uint32_t A2 = EltToVoid.GetSize() + EltToVoid.HeadSize();
   if (GetSize() + HeadSize() != EltToVoid.GetSize() + EltToVoid.HeadSize()) {
     SetSize(GetSize()-1);
     SetSizeLength(CodedSizeLength(GetSize(), GetSizeLength(), IsFiniteSize()) + 1);

--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -45,7 +45,7 @@ using namespace std;
 
 START_LIBEBML_NAMESPACE
 
-void IOCallback::writeFully(const void*Buffer,size_t Size)
+void IOCallback::writeFully(const void*Buffer,std::size_t Size)
 {
   if (Size == 0)
     return;
@@ -64,7 +64,7 @@ void IOCallback::writeFully(const void*Buffer,size_t Size)
 
 
 
-void IOCallback::readFully(void*Buffer,size_t Size)
+void IOCallback::readFully(void*Buffer,std::size_t Size)
 {
   if(Buffer == nullptr)
     throw;

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -38,7 +38,7 @@
 
 START_LIBEBML_NAMESPACE
 
-MemIOCallback::MemIOCallback(uint64 DefaultSize)
+MemIOCallback::MemIOCallback(std::uint64_t DefaultSize)
 {
   //The default size of the buffer is 128 bytes
   dataBuffer = static_cast<binary *>(malloc(DefaultSize));
@@ -63,7 +63,7 @@ MemIOCallback::~MemIOCallback()
     free(dataBuffer);
 }
 
-uint32 MemIOCallback::read(void *Buffer, size_t Size)
+std::uint32_t MemIOCallback::read(void *Buffer, std::size_t Size)
 {
   if (Buffer == nullptr || Size < 1)
     return 0;
@@ -71,7 +71,7 @@ uint32 MemIOCallback::read(void *Buffer, size_t Size)
   if (Size + dataBufferPos > dataBufferTotalSize) {
     //We will only return the remaining data
     memcpy(Buffer, dataBuffer + dataBufferPos, dataBufferTotalSize - dataBufferPos);
-    uint64 oldDataPos = dataBufferPos;
+    std::uint64_t oldDataPos = dataBufferPos;
     dataBufferPos = dataBufferTotalSize;
     return dataBufferTotalSize - oldDataPos;
   }
@@ -83,7 +83,7 @@ uint32 MemIOCallback::read(void *Buffer, size_t Size)
   return Size;
 }
 
-void MemIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
+void MemIOCallback::setFilePointer(std::int64_t Offset, seek_mode Mode)
 {
   if (Mode == seek_beginning)
     dataBufferPos = Offset;
@@ -93,7 +93,7 @@ void MemIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
     dataBufferPos = dataBufferTotalSize + Offset;
 }
 
-size_t MemIOCallback::write(const void *Buffer, size_t Size)
+std::size_t MemIOCallback::write(const void *Buffer, std::size_t Size)
 {
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
@@ -107,7 +107,7 @@ size_t MemIOCallback::write(const void *Buffer, size_t Size)
   return Size;
 }
 
-uint32 MemIOCallback::write(IOCallback & IOToRead, size_t Size)
+std::uint32_t MemIOCallback::write(IOCallback & IOToRead, std::size_t Size)
 {
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!

--- a/src/MemReadIOCallback.cpp
+++ b/src/MemReadIOCallback.cpp
@@ -42,7 +42,7 @@
 START_LIBEBML_NAMESPACE
 
 MemReadIOCallback::MemReadIOCallback(void const *Ptr,
-                                     size_t Size) {
+                                     std::size_t Size) {
   Init(Ptr, Size);
 }
 
@@ -56,16 +56,16 @@ MemReadIOCallback::MemReadIOCallback(MemReadIOCallback const &Mem) {
 
 void
 MemReadIOCallback::Init(void const *Ptr,
-                        size_t Size) {
-  mStart = reinterpret_cast<uint8 const *>(Ptr);
+                        std::size_t Size) {
+  mStart = reinterpret_cast<std::uint8_t const *>(Ptr);
   mEnd   = mStart + Size;
   mPtr   = mStart;
 }
 
-uint32
+std::uint32_t
 MemReadIOCallback::read(void *Buffer,
-                        size_t Size) {
-  size_t RemainingBytes = mEnd - mPtr;
+                        std::size_t Size) {
+  std::size_t RemainingBytes = mEnd - mPtr;
   if (RemainingBytes < Size)
     Size = RemainingBytes;
 
@@ -76,13 +76,13 @@ MemReadIOCallback::read(void *Buffer,
 }
 
 void
-MemReadIOCallback::setFilePointer(int64 Offset,
+MemReadIOCallback::setFilePointer(std::int64_t Offset,
                                   seek_mode Mode) {
-  int64 NewPosition = Mode == seek_beginning ? Offset
-                    : Mode == seek_end       ? static_cast<int64>(mEnd - mStart) + Offset
-                    :                          static_cast<int64>(mPtr - mStart) + Offset;
+  std::int64_t NewPosition = Mode == seek_beginning ? Offset
+                    : Mode == seek_end       ? static_cast<std::int64_t>(mEnd - mStart) + Offset
+                    :                          static_cast<std::int64_t>(mPtr - mStart) + Offset;
 
-  NewPosition = std::min<int64>(std::max<int64>(NewPosition, 0), mEnd - mStart);
+  NewPosition = std::min<std::int64_t>(std::max<std::int64_t>(NewPosition, 0), mEnd - mStart);
   mPtr = mStart + NewPosition;
 }
 

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -42,7 +42,7 @@
 
 START_LIBEBML_NAMESPACE
 
-SafeReadIOCallback::EndOfStreamX::EndOfStreamX(size_t MissingBytes)
+SafeReadIOCallback::EndOfStreamX::EndOfStreamX(std::size_t MissingBytes)
   : mMissingBytes(MissingBytes)
 {
 }
@@ -55,7 +55,7 @@ SafeReadIOCallback::SafeReadIOCallback(IOCallback *IO,
 }
 
 SafeReadIOCallback::SafeReadIOCallback(void const *Mem,
-                                       size_t Size) {
+                                       std::size_t Size) {
   Init(new MemReadIOCallback(Mem, Size), true);
 }
 
@@ -73,25 +73,25 @@ SafeReadIOCallback::Init(IOCallback *IO,
                          bool DeleteIO) {
   mIO                = IO;
   mDeleteIO          = DeleteIO;
-  int64 PrevPosition = IO->getFilePointer();
+  std::int64_t PrevPosition = IO->getFilePointer();
   IO->setFilePointer(0, seek_end);
   mSize              = IO->getFilePointer();
   IO->setFilePointer(PrevPosition);
 }
 
-size_t
+std::size_t
 SafeReadIOCallback::GetPosition()
   const {
   return mIO->getFilePointer();
 }
 
-size_t
+std::size_t
 SafeReadIOCallback::GetSize()
   const {
   return mSize;
 }
 
-size_t
+std::size_t
 SafeReadIOCallback::GetRemainingBytes()
   const {
   return GetSize() - GetPosition();
@@ -103,70 +103,70 @@ SafeReadIOCallback::IsEmpty()
   return !GetRemainingBytes();
 }
 
-uint64
-SafeReadIOCallback::GetUIntBE(size_t NumBytes) {
-  uint8 Buffer[8];
+std::uint64_t
+SafeReadIOCallback::GetUIntBE(std::size_t NumBytes) {
+  std::uint8_t Buffer[8];
 
-  NumBytes     = std::min<size_t>(std::max<size_t>(1, NumBytes), 8);
-  uint64 Value = 0;
-  uint8* Ptr   = &Buffer[0];
+  NumBytes     = std::min<std::size_t>(std::max<std::size_t>(1, NumBytes), 8);
+  std::uint64_t Value = 0;
+  std::uint8_t* Ptr   = &Buffer[0];
 
   Read(Buffer, NumBytes);
 
-  for (size_t i = 0; NumBytes > i; ++i, ++Ptr)
+  for (std::size_t i = 0; NumBytes > i; ++i, ++Ptr)
     Value = (Value << 8) + *Ptr;
 
   return Value;
 }
 
-uint8
+std::uint8_t
 SafeReadIOCallback::GetUInt8() {
   return GetUIntBE(1);
 }
 
-uint16
+std::uint16_t
 SafeReadIOCallback::GetUInt16BE() {
   return GetUIntBE(2);
 }
 
-uint32
+std::uint32_t
 SafeReadIOCallback::GetUInt24BE() {
   return GetUIntBE(3);
 }
 
-uint32
+std::uint32_t
 SafeReadIOCallback::GetUInt32BE() {
   return GetUIntBE(4);
 }
 
-uint64
+std::uint64_t
 SafeReadIOCallback::GetUInt64BE() {
   return GetUIntBE(8);
 }
 
 void
-SafeReadIOCallback::Skip(size_t Count) {
-  int64 PrevPosition     = mIO->getFilePointer();
-  int64 ExpectedPosition = PrevPosition + Count;
+SafeReadIOCallback::Skip(std::size_t Count) {
+  std::int64_t PrevPosition     = mIO->getFilePointer();
+  std::int64_t ExpectedPosition = PrevPosition + Count;
   mIO->setFilePointer(Count, seek_current);
-  int64 ActualPosition   = mIO->getFilePointer();
+  std::int64_t ActualPosition   = mIO->getFilePointer();
 
   if (ActualPosition != ExpectedPosition)
     throw SafeReadIOCallback::EndOfStreamX(ExpectedPosition - ActualPosition);
 }
 
 void
-SafeReadIOCallback::Seek(size_t Position) {
+SafeReadIOCallback::Seek(std::size_t Position) {
   mIO->setFilePointer(Position);
-  uint64 ActualPosition = mIO->getFilePointer();
+  std::uint64_t ActualPosition = mIO->getFilePointer();
   if (ActualPosition != Position)
     throw EndOfStreamX(ActualPosition - Position);
 }
 
 void
 SafeReadIOCallback::Read(void *Dst,
-                       size_t Count) {
-  uint64 NumRead = mIO->read(Dst, Count);
+                       std::size_t Count) {
+  std::uint64_t NumRead = mIO->read(Dst, Count);
   if (NumRead != Count)
     throw SafeReadIOCallback::EndOfStreamX(Count - NumRead);
 }

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -101,16 +101,16 @@ StdIOCallback::~StdIOCallback() noexcept
 
 
 
-uint32 StdIOCallback::read(void*Buffer,size_t Size)
+std::uint32_t StdIOCallback::read(void*Buffer,std::size_t Size)
 {
   assert(File!=nullptr);
 
-  size_t result = fread(Buffer, 1, Size, File);
+  std::size_t result = fread(Buffer, 1, Size, File);
   mCurrentPosition += result;
   return result;
 }
 
-void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
+void StdIOCallback::setFilePointer(std::int64_t Offset,seek_mode Mode)
 {
   assert(File!=nullptr);
 
@@ -149,15 +149,15 @@ void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
   }
 }
 
-size_t StdIOCallback::write(const void*Buffer,size_t Size)
+std::size_t StdIOCallback::write(const void*Buffer,std::size_t Size)
 {
   assert(File!=nullptr);
-  uint32 Result = fwrite(Buffer,1,Size,File);
+  std::uint32_t Result = fwrite(Buffer,1,Size,File);
   mCurrentPosition += Result;
   return Result;
 }
 
-uint64 StdIOCallback::getFilePointer()
+std::uint64_t StdIOCallback::getFilePointer()
 {
   assert(File!=nullptr);
 

--- a/src/lib/utf8-cpp/README.md
+++ b/src/lib/utf8-cpp/README.md
@@ -199,7 +199,7 @@ Encodes a 32 bit code point as a UTF-8 sequence of octets and appends the sequen
 
 ```cpp
 template <typename octet_iterator>
-octet_iterator append(uint32_t cp, octet_iterator result);
+octet_iterator append(std::uint32_t cp, octet_iterator result);
 ```
 
 `octet_iterator`: an output iterator.  
@@ -227,7 +227,7 @@ Given the iterator to the beginning of the UTF-8 sequence, it returns the code p
 
 ```cpp
 template <typename octet_iterator> 
-uint32_t next(octet_iterator& it, octet_iterator end);
+std::uint32_t next(octet_iterator& it, octet_iterator end);
 ```
 
 `octet_iterator`: an input iterator.  
@@ -257,7 +257,7 @@ Given the iterator to the beginning of the UTF-8 sequence, it returns the code p
 
 ```cpp
 template <typename octet_iterator> 
-uint32_t peek_next(octet_iterator it, octet_iterator end);
+std::uint32_t peek_next(octet_iterator it, octet_iterator end);
 ```
 
 
@@ -286,7 +286,7 @@ Given a reference to an iterator pointing to an octet in a UTF-8 sequence, it de
 
 ```cpp
 template <typename octet_iterator> 
-uint32_t prior(octet_iterator& it, octet_iterator start);
+std::uint32_t prior(octet_iterator& it, octet_iterator start);
 ```
 
 `octet_iterator`: a bidirectional iterator.  
@@ -361,7 +361,7 @@ Example of use:
 
 ```cpp
 char* twochars = "\xe6\x97\xa5\xd1\x88";
-size_t dist = utf8::distance(twochars, twochars + 5);
+std::size_t dist = utf8::distance(twochars, twochars + 5);
 assert (dist == 2);
 ```
 
@@ -589,7 +589,7 @@ Available in version 3.0 and later. Requires a C++ 11 compliant compiler.
 Detects an invalid sequence within a UTF-8 string.
 
 ```cpp
-std::size_t find_invalid(const std::string& s);
+std::std::size_t find_invalid(const std::string& s);
 ```
 
 `s`: a UTF-8 encoded string.
@@ -714,7 +714,7 @@ Replaces all invalid UTF-8 sequences within a string with a replacement marker.
 
 ```cpp
 template <typename octet_iterator, typename output_iterator>
-output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, uint32_t replacement);
+output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, std::uint32_t replacement);
 template <typename octet_iterator, typename output_iterator>
 output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out);
 ```
@@ -826,7 +826,7 @@ Thrown by UTF8 CPP functions such as `advance` and `next` if an UTF-8 sequence r
 ```cpp
 class invalid_code_point : public exception {
 public: 
-    uint32_t code_point() const;
+    std::uint32_t code_point() const;
 };
 ```
 
@@ -841,7 +841,7 @@ Thrown by UTF8 CPP functions such as `next` and `prior` if an invalid UTF-8 sequ
 ```cpp
 class invalid_utf8 : public exception {
 public: 
-    uint8_t utf8_octet() const;
+    std::uint8_t utf8_octet() const;
 };
 ```
 
@@ -856,7 +856,7 @@ Thrown by UTF8 CPP function `utf16to8` if an invalid UTF-16 sequence is detected
 ```cpp
 class invalid_utf16 : public exception {
 public: 
-    uint16_t utf16_word() const;
+    std::uint16_t utf16_word() const;
 };
 ```
 
@@ -891,7 +891,7 @@ class iterator;
 
 `octet_iterator base () const;` returns the underlying octet_iterator.
 
-`uint32_t operator * () const;` decodes the utf-8 sequence the underlying octet_iterator is pointing to and returns the code point.
+`std::uint32_t operator * () const;` decodes the utf-8 sequence the underlying octet_iterator is pointing to and returns the code point.
 
 `bool operator == (const iterator& rhs) const;` returns `true` if the two underlaying iterators are equal.
 
@@ -945,7 +945,7 @@ Encodes a 32 bit code point as a UTF-8 sequence of octets and appends the sequen
 
 ```cpp
 template <typename octet_iterator>
-octet_iterator append(uint32_t cp, octet_iterator result);
+octet_iterator append(std::uint32_t cp, octet_iterator result);
 ```
 
 `cp`: A 32 bit integer representing a code point to append to the sequence.  
@@ -970,7 +970,7 @@ Given the iterator to the beginning of a UTF-8 sequence, it returns the code poi
 
 ```cpp
 template <typename octet_iterator>
-uint32_t next(octet_iterator& it);
+std::uint32_t next(octet_iterator& it);
 ```
 
 `it`: a reference to an iterator pointing to the beginning of an UTF-8 encoded code point. After the function returns, it is incremented to point to the beginning of the next code point.  
@@ -996,7 +996,7 @@ Given the iterator to the beginning of a UTF-8 sequence, it returns the code poi
 
 ```cpp
 template <typename octet_iterator>
-uint32_t peek_next(octet_iterator it);
+std::uint32_t peek_next(octet_iterator it);
 ```
 
 `it`: an iterator pointing to the beginning of an UTF-8 encoded code point.  
@@ -1022,7 +1022,7 @@ Given a reference to an iterator pointing to an octet in a UTF-8 seqence, it dec
 
 ```cpp
 template <typename octet_iterator>
-uint32_t prior(octet_iterator& it);
+std::uint32_t prior(octet_iterator& it);
 ```
 
 `it`: a reference pointing to an octet within a UTF-8 encoded string. After the function returns, it is decremented to point to the beginning of the previous code point.  
@@ -1084,7 +1084,7 @@ Example of use:
 
 ```cpp
 char* twochars = "\xe6\x97\xa5\xd1\x88";
-size_t dist = utf8::unchecked::distance(twochars, twochars + 5);
+std::size_t dist = utf8::unchecked::distance(twochars, twochars + 5);
 assert (dist == 2);
 ```
 
@@ -1207,7 +1207,7 @@ Replaces all invalid UTF-8 sequences within a string with a replacement marker.
 
 ```cpp
 template <typename octet_iterator, typename output_iterator>
-output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, uint32_t replacement);
+output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, std::uint32_t replacement);
 template <typename octet_iterator, typename output_iterator>
 output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out);
 ```
@@ -1257,7 +1257,7 @@ class iterator;
 
 `octet_iterator base () const;` returns the underlying octet_iterator.
 
-`uint32_t operator * () const;` decodes the utf-8 sequence the underlying octet_iterator is pointing to and returns the code point.
+`std::uint32_t operator * () const;` decodes the utf-8 sequence the underlying octet_iterator is pointing to and returns the code point.
 
 `bool operator == (const iterator& rhs) const;` returns `true` if the two underlaying iterators are equal.
 

--- a/src/lib/utf8-cpp/source/utf8/checked.h
+++ b/src/lib/utf8-cpp/source/utf8/checked.h
@@ -39,27 +39,27 @@ namespace utf8
 
     // Exceptions that may be thrown from the library functions.
     class invalid_code_point : public exception {
-        uint32_t cp;
+        std::uint32_t cp;
     public:
-        invalid_code_point(uint32_t codepoint) : cp(codepoint) {}
+        invalid_code_point(std::uint32_t codepoint) : cp(codepoint) {}
         virtual const char* what() const UTF_CPP_NOEXCEPT UTF_CPP_OVERRIDE { return "Invalid code point"; }
-        uint32_t code_point() const {return cp;}
+        std::uint32_t code_point() const {return cp;}
     };
 
     class invalid_utf8 : public exception {
-        uint8_t u8;
+        std::uint8_t u8;
     public:
-        invalid_utf8 (uint8_t u) : u8(u) {}
+        invalid_utf8 (std::uint8_t u) : u8(u) {}
         virtual const char* what() const UTF_CPP_NOEXCEPT UTF_CPP_OVERRIDE { return "Invalid UTF-8"; }
-        uint8_t utf8_octet() const {return u8;}
+        std::uint8_t utf8_octet() const {return u8;}
     };
 
     class invalid_utf16 : public exception {
-        uint16_t u16;
+        std::uint16_t u16;
     public:
-        invalid_utf16 (uint16_t u) : u16(u) {}
+        invalid_utf16 (std::uint16_t u) : u16(u) {}
         virtual const char* what() const UTF_CPP_NOEXCEPT UTF_CPP_OVERRIDE { return "Invalid UTF-16"; }
-        uint16_t utf16_word() const {return u16;}
+        std::uint16_t utf16_word() const {return u16;}
     };
 
     class not_enough_room : public exception {
@@ -70,33 +70,33 @@ namespace utf8
     /// The library API - functions intended to be called by the users
 
     template <typename octet_iterator>
-    octet_iterator append(uint32_t cp, octet_iterator result)
+    octet_iterator append(std::uint32_t cp, octet_iterator result)
     {
         if (!utf8::internal::is_code_point_valid(cp))
             throw invalid_code_point(cp);
 
         if (cp < 0x80)                        // one octet
-            *(result++) = static_cast<uint8_t>(cp);
+            *(result++) = static_cast<std::uint8_t>(cp);
         else if (cp < 0x800) {                // two octets
-            *(result++) = static_cast<uint8_t>((cp >> 6)            | 0xc0);
-            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
+            *(result++) = static_cast<std::uint8_t>((cp >> 6)            | 0xc0);
+            *(result++) = static_cast<std::uint8_t>((cp & 0x3f)          | 0x80);
         }
         else if (cp < 0x10000) {              // three octets
-            *(result++) = static_cast<uint8_t>((cp >> 12)           | 0xe0);
-            *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
-            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
+            *(result++) = static_cast<std::uint8_t>((cp >> 12)           | 0xe0);
+            *(result++) = static_cast<std::uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
+            *(result++) = static_cast<std::uint8_t>((cp & 0x3f)          | 0x80);
         }
         else {                                // four octets
-            *(result++) = static_cast<uint8_t>((cp >> 18)           | 0xf0);
-            *(result++) = static_cast<uint8_t>(((cp >> 12) & 0x3f)  | 0x80);
-            *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
-            *(result++) = static_cast<uint8_t>((cp & 0x3f)          | 0x80);
+            *(result++) = static_cast<std::uint8_t>((cp >> 18)           | 0xf0);
+            *(result++) = static_cast<std::uint8_t>(((cp >> 12) & 0x3f)  | 0x80);
+            *(result++) = static_cast<std::uint8_t>(((cp >> 6) & 0x3f)   | 0x80);
+            *(result++) = static_cast<std::uint8_t>((cp & 0x3f)          | 0x80);
         }
         return result;
     }
 
     template <typename octet_iterator, typename output_iterator>
-    output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, uint32_t replacement)
+    output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, std::uint32_t replacement)
     {
         while (start != end) {
             octet_iterator sequence_start = start;
@@ -131,14 +131,14 @@ namespace utf8
     template <typename octet_iterator, typename output_iterator>
     inline output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out)
     {
-        static const uint32_t replacement_marker = utf8::internal::mask16(0xfffd);
+        static const std::uint32_t replacement_marker = utf8::internal::mask16(0xfffd);
         return utf8::replace_invalid(start, end, out, replacement_marker);
     }
 
     template <typename octet_iterator>
-    uint32_t next(octet_iterator& it, octet_iterator end)
+    std::uint32_t next(octet_iterator& it, octet_iterator end)
     {
-        uint32_t cp = 0;
+        std::uint32_t cp = 0;
         internal::utf_error err_code = utf8::internal::validate_next(it, end, cp);
         switch (err_code) {
             case internal::UTF8_OK :
@@ -156,13 +156,13 @@ namespace utf8
     }
 
     template <typename octet_iterator>
-    uint32_t peek_next(octet_iterator it, octet_iterator end)
+    std::uint32_t peek_next(octet_iterator it, octet_iterator end)
     {
         return utf8::next(it, end);
     }
 
     template <typename octet_iterator>
-    uint32_t prior(octet_iterator& it, octet_iterator start)
+    std::uint32_t prior(octet_iterator& it, octet_iterator start)
     {
         // can't do much if it == start
         if (it == start)
@@ -205,23 +205,23 @@ namespace utf8
     octet_iterator utf16to8 (u16bit_iterator start, u16bit_iterator end, octet_iterator result)
     {
         while (start != end) {
-            uint32_t cp = utf8::internal::mask16(*start++);
+            std::uint32_t cp = utf8::internal::mask16(*start++);
             // Take care of surrogate pairs first
             if (utf8::internal::is_lead_surrogate(cp)) {
                 if (start != end) {
-                    uint32_t trail_surrogate = utf8::internal::mask16(*start++);
+                    std::uint32_t trail_surrogate = utf8::internal::mask16(*start++);
                     if (utf8::internal::is_trail_surrogate(trail_surrogate))
                         cp = (cp << 10) + trail_surrogate + internal::SURROGATE_OFFSET;
                     else
-                        throw invalid_utf16(static_cast<uint16_t>(trail_surrogate));
+                        throw invalid_utf16(static_cast<std::uint16_t>(trail_surrogate));
                 }
                 else
-                    throw invalid_utf16(static_cast<uint16_t>(cp));
+                    throw invalid_utf16(static_cast<std::uint16_t>(cp));
 
             }
             // Lone trail surrogate
             else if (utf8::internal::is_trail_surrogate(cp))
-                throw invalid_utf16(static_cast<uint16_t>(cp));
+                throw invalid_utf16(static_cast<std::uint16_t>(cp));
 
             result = utf8::append(cp, result);
         }
@@ -232,13 +232,13 @@ namespace utf8
     u16bit_iterator utf8to16 (octet_iterator start, octet_iterator end, u16bit_iterator result)
     {
         while (start < end) {
-            uint32_t cp = utf8::next(start, end);
+            std::uint32_t cp = utf8::next(start, end);
             if (cp > 0xffff) { //make a surrogate pair
-                *result++ = static_cast<uint16_t>((cp >> 10)   + internal::LEAD_OFFSET);
-                *result++ = static_cast<uint16_t>((cp & 0x3ff) + internal::TRAIL_SURROGATE_MIN);
+                *result++ = static_cast<std::uint16_t>((cp >> 10)   + internal::LEAD_OFFSET);
+                *result++ = static_cast<std::uint16_t>((cp & 0x3ff) + internal::TRAIL_SURROGATE_MIN);
             }
             else
-                *result++ = static_cast<uint16_t>(cp);
+                *result++ = static_cast<std::uint16_t>(cp);
         }
         return result;
     }
@@ -268,9 +268,9 @@ namespace utf8
       octet_iterator range_start;
       octet_iterator range_end;
       public:
-      typedef uint32_t value_type;
-      typedef uint32_t* pointer;
-      typedef uint32_t& reference;
+      typedef std::uint32_t value_type;
+      typedef std::uint32_t* pointer;
+      typedef std::uint32_t& reference;
       typedef std::ptrdiff_t difference_type;
       typedef std::bidirectional_iterator_tag iterator_category;
       iterator () {}
@@ -284,7 +284,7 @@ namespace utf8
       }
       // the default "big three" are OK
       octet_iterator base () const { return it; }
-      uint32_t operator * () const
+      std::uint32_t operator * () const
       {
           octet_iterator temp = it;
           return utf8::next(temp, range_end);

--- a/src/lib/utf8-cpp/source/utf8/core.h
+++ b/src/lib/utf8-cpp/source/utf8/core.h
@@ -62,25 +62,25 @@ namespace internal
     // Unicode constants
     // Leading (high) surrogates: 0xd800 - 0xdbff
     // Trailing (low) surrogates: 0xdc00 - 0xdfff
-    const uint16_t LEAD_SURROGATE_MIN  = 0xd800u;
-    const uint16_t LEAD_SURROGATE_MAX  = 0xdbffu;
-    const uint16_t TRAIL_SURROGATE_MIN = 0xdc00u;
-    const uint16_t TRAIL_SURROGATE_MAX = 0xdfffu;
-    const uint16_t LEAD_OFFSET         = 0xd7c0u;       // LEAD_SURROGATE_MIN - (0x10000 >> 10)
-    const uint32_t SURROGATE_OFFSET    = 0xfca02400u;   // 0x10000u - (LEAD_SURROGATE_MIN << 10) - TRAIL_SURROGATE_MIN
+    const std::uint16_t LEAD_SURROGATE_MIN  = 0xd800u;
+    const std::uint16_t LEAD_SURROGATE_MAX  = 0xdbffu;
+    const std::uint16_t TRAIL_SURROGATE_MIN = 0xdc00u;
+    const std::uint16_t TRAIL_SURROGATE_MAX = 0xdfffu;
+    const std::uint16_t LEAD_OFFSET         = 0xd7c0u;       // LEAD_SURROGATE_MIN - (0x10000 >> 10)
+    const std::uint32_t SURROGATE_OFFSET    = 0xfca02400u;   // 0x10000u - (LEAD_SURROGATE_MIN << 10) - TRAIL_SURROGATE_MIN
 
     // Maximum valid value for a Unicode code point
-    const uint32_t CODE_POINT_MAX      = 0x0010ffffu;
+    const std::uint32_t CODE_POINT_MAX      = 0x0010ffffu;
 
     template<typename octet_type>
-    inline uint8_t mask8(octet_type oc)
+    inline std::uint8_t mask8(octet_type oc)
     {
-        return static_cast<uint8_t>(0xff & oc);
+        return static_cast<std::uint8_t>(0xff & oc);
     }
     template<typename u16_type>
-    inline uint16_t mask16(u16_type oc)
+    inline std::uint16_t mask16(u16_type oc)
     {
-        return static_cast<uint16_t>(0xffff & oc);
+        return static_cast<std::uint16_t>(0xffff & oc);
     }
     template<typename octet_type>
     inline bool is_trail(octet_type oc)
@@ -116,7 +116,7 @@ namespace internal
     inline typename std::iterator_traits<octet_iterator>::difference_type
     sequence_length(octet_iterator lead_it)
     {
-        uint8_t lead = utf8::internal::mask8(*lead_it);
+        std::uint8_t lead = utf8::internal::mask8(*lead_it);
         if (lead < 0x80)
             return 1;
         else if ((lead >> 5) == 0x6)
@@ -130,7 +130,7 @@ namespace internal
     }
 
     template <typename octet_difference_type>
-    inline bool is_overlong_sequence(uint32_t cp, octet_difference_type length)
+    inline bool is_overlong_sequence(std::uint32_t cp, octet_difference_type length)
     {
         if (cp < 0x80) {
             if (length != 1) 
@@ -167,7 +167,7 @@ namespace internal
 
     /// get_sequence_x functions decode utf-8 sequences of the length x
     template <typename octet_iterator>
-    utf_error get_sequence_1(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    utf_error get_sequence_1(octet_iterator& it, octet_iterator end, std::uint32_t& code_point)
     {
         if (it == end)
             return NOT_ENOUGH_ROOM;
@@ -178,7 +178,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    utf_error get_sequence_2(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    utf_error get_sequence_2(octet_iterator& it, octet_iterator end, std::uint32_t& code_point)
     {
         if (it == end) 
             return NOT_ENOUGH_ROOM;
@@ -193,7 +193,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    utf_error get_sequence_3(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    utf_error get_sequence_3(octet_iterator& it, octet_iterator end, std::uint32_t& code_point)
     {
         if (it == end)
             return NOT_ENOUGH_ROOM;
@@ -212,7 +212,7 @@ namespace internal
     }
 
     template <typename octet_iterator>
-    utf_error get_sequence_4(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    utf_error get_sequence_4(octet_iterator& it, octet_iterator end, std::uint32_t& code_point)
     {
         if (it == end)
            return NOT_ENOUGH_ROOM;
@@ -237,7 +237,7 @@ namespace internal
     #undef UTF8_CPP_INCREASE_AND_RETURN_ON_ERROR
 
     template <typename octet_iterator>
-    utf_error validate_next(octet_iterator& it, octet_iterator end, uint32_t& code_point)
+    utf_error validate_next(octet_iterator& it, octet_iterator end, std::uint32_t& code_point)
     {
         if (it == end)
             return NOT_ENOUGH_ROOM;
@@ -246,7 +246,7 @@ namespace internal
         // Of course, it does not make much sense with i.e. stream iterators
         octet_iterator original_it = it;
 
-        uint32_t cp = 0;
+        std::uint32_t cp = 0;
         // Determine the sequence length based on the lead octet
         typedef typename std::iterator_traits<octet_iterator>::difference_type octet_difference_type;
         const octet_difference_type length = utf8::internal::sequence_length(it);
@@ -293,7 +293,7 @@ namespace internal
 
     template <typename octet_iterator>
     inline utf_error validate_next(octet_iterator& it, octet_iterator end) {
-        uint32_t ignored;
+        std::uint32_t ignored;
         return utf8::internal::validate_next(it, end, ignored);
     }
 
@@ -302,7 +302,7 @@ namespace internal
     /// The library API - functions intended to be called by the users
 
     // Byte order mark
-    const uint8_t bom[] = {0xef, 0xbb, 0xbf};
+    const std::uint8_t bom[] = {0xef, 0xbb, 0xbf};
 
     template <typename octet_iterator>
     octet_iterator find_invalid(octet_iterator start, octet_iterator end)

--- a/src/lib/utf8-cpp/source/utf8/cpp11.h
+++ b/src/lib/utf8-cpp/source/utf8/cpp11.h
@@ -36,7 +36,7 @@ namespace utf8
 
     inline void append(char32_t cp, std::string& s)
     {
-        append(uint32_t(cp), std::back_inserter(s));
+        append(std::uint32_t(cp), std::back_inserter(s));
     }
 
     inline std::string utf16to8(const std::u16string& s)

--- a/src/lib/utf8-cpp/source/utf8/unchecked.h
+++ b/src/lib/utf8-cpp/source/utf8/unchecked.h
@@ -35,30 +35,30 @@ namespace utf8
     namespace unchecked
     {
         template <typename octet_iterator>
-        octet_iterator append(uint32_t cp, octet_iterator result)
+        octet_iterator append(std::uint32_t cp, octet_iterator result)
         {
             if (cp < 0x80)                        // one octet
-                *(result++) = static_cast<uint8_t>(cp);
+                *(result++) = static_cast<std::uint8_t>(cp);
             else if (cp < 0x800) {                // two octets
-                *(result++) = static_cast<uint8_t>((cp >> 6)          | 0xc0);
-                *(result++) = static_cast<uint8_t>((cp & 0x3f)        | 0x80);
+                *(result++) = static_cast<std::uint8_t>((cp >> 6)          | 0xc0);
+                *(result++) = static_cast<std::uint8_t>((cp & 0x3f)        | 0x80);
             }
             else if (cp < 0x10000) {              // three octets
-                *(result++) = static_cast<uint8_t>((cp >> 12)         | 0xe0);
-                *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f) | 0x80);
-                *(result++) = static_cast<uint8_t>((cp & 0x3f)        | 0x80);
+                *(result++) = static_cast<std::uint8_t>((cp >> 12)         | 0xe0);
+                *(result++) = static_cast<std::uint8_t>(((cp >> 6) & 0x3f) | 0x80);
+                *(result++) = static_cast<std::uint8_t>((cp & 0x3f)        | 0x80);
             }
             else {                                // four octets
-                *(result++) = static_cast<uint8_t>((cp >> 18)         | 0xf0);
-                *(result++) = static_cast<uint8_t>(((cp >> 12) & 0x3f)| 0x80);
-                *(result++) = static_cast<uint8_t>(((cp >> 6) & 0x3f) | 0x80);
-                *(result++) = static_cast<uint8_t>((cp & 0x3f)        | 0x80);
+                *(result++) = static_cast<std::uint8_t>((cp >> 18)         | 0xf0);
+                *(result++) = static_cast<std::uint8_t>(((cp >> 12) & 0x3f)| 0x80);
+                *(result++) = static_cast<std::uint8_t>(((cp >> 6) & 0x3f) | 0x80);
+                *(result++) = static_cast<std::uint8_t>((cp & 0x3f)        | 0x80);
             }
             return result;
         }
 
         template <typename octet_iterator, typename output_iterator>
-        output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, uint32_t replacement)
+        output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out, std::uint32_t replacement)
         {
             while (start != end) {
                 octet_iterator sequence_start = start;
@@ -93,14 +93,14 @@ namespace utf8
         template <typename octet_iterator, typename output_iterator>
         inline output_iterator replace_invalid(octet_iterator start, octet_iterator end, output_iterator out)
         {
-            static const uint32_t replacement_marker = utf8::internal::mask16(0xfffd);
+            static const std::uint32_t replacement_marker = utf8::internal::mask16(0xfffd);
             return utf8::unchecked::replace_invalid(start, end, out, replacement_marker);
         }
 
         template <typename octet_iterator>
-        uint32_t next(octet_iterator& it)
+        std::uint32_t next(octet_iterator& it)
         {
-            uint32_t cp = utf8::internal::mask8(*it);
+            std::uint32_t cp = utf8::internal::mask8(*it);
             typename std::iterator_traits<octet_iterator>::difference_type length = utf8::internal::sequence_length(it);
             switch (length) {
                 case 1:
@@ -129,13 +129,13 @@ namespace utf8
         }
 
         template <typename octet_iterator>
-        uint32_t peek_next(octet_iterator it)
+        std::uint32_t peek_next(octet_iterator it)
         {
             return utf8::unchecked::next(it);
         }
 
         template <typename octet_iterator>
-        uint32_t prior(octet_iterator& it)
+        std::uint32_t prior(octet_iterator& it)
         {
             while (utf8::internal::is_trail(*(--it))) ;
             octet_iterator temp = it;
@@ -171,10 +171,10 @@ namespace utf8
         octet_iterator utf16to8 (u16bit_iterator start, u16bit_iterator end, octet_iterator result)
         {
             while (start != end) {
-                uint32_t cp = utf8::internal::mask16(*start++);
+                std::uint32_t cp = utf8::internal::mask16(*start++);
             // Take care of surrogate pairs first
                 if (utf8::internal::is_lead_surrogate(cp)) {
-                    uint32_t trail_surrogate = utf8::internal::mask16(*start++);
+                    std::uint32_t trail_surrogate = utf8::internal::mask16(*start++);
                     cp = (cp << 10) + trail_surrogate + internal::SURROGATE_OFFSET;
                 }
                 result = utf8::unchecked::append(cp, result);
@@ -186,13 +186,13 @@ namespace utf8
         u16bit_iterator utf8to16 (octet_iterator start, octet_iterator end, u16bit_iterator result)
         {
             while (start < end) {
-                uint32_t cp = utf8::unchecked::next(start);
+                std::uint32_t cp = utf8::unchecked::next(start);
                 if (cp > 0xffff) { //make a surrogate pair
-                    *result++ = static_cast<uint16_t>((cp >> 10)   + internal::LEAD_OFFSET);
-                    *result++ = static_cast<uint16_t>((cp & 0x3ff) + internal::TRAIL_SURROGATE_MIN);
+                    *result++ = static_cast<std::uint16_t>((cp >> 10)   + internal::LEAD_OFFSET);
+                    *result++ = static_cast<std::uint16_t>((cp & 0x3ff) + internal::TRAIL_SURROGATE_MIN);
                 }
                 else
-                    *result++ = static_cast<uint16_t>(cp);
+                    *result++ = static_cast<std::uint16_t>(cp);
             }
             return result;
         }
@@ -220,16 +220,16 @@ namespace utf8
           class iterator {
             octet_iterator it;
             public:
-            typedef uint32_t value_type;
-            typedef uint32_t* pointer;
-            typedef uint32_t& reference;
+            typedef std::uint32_t value_type;
+            typedef std::uint32_t* pointer;
+            typedef std::uint32_t& reference;
             typedef std::ptrdiff_t difference_type;
             typedef std::bidirectional_iterator_tag iterator_category;
             iterator () {}
             explicit iterator (const octet_iterator& octet_it): it(octet_it) {}
             // the default "big three" are OK
             octet_iterator base () const { return it; }
-            uint32_t operator * () const
+            std::uint32_t operator * () const
             {
                 octet_iterator temp = it;
                 return utf8::unchecked::next(temp);

--- a/src/platform/win32/WinIOCallback.cpp
+++ b/src/platform/win32/WinIOCallback.cpp
@@ -203,7 +203,7 @@ void WinIOCallback::close()
   }
 }
 
-uint64 WinIOCallback::getFilePointer()
+std::uint64_t WinIOCallback::getFilePointer()
 {
   if (!mFile) {
     return 0;
@@ -214,12 +214,12 @@ uint64 WinIOCallback::getFilePointer()
   LONG High = 0;
   DWORD Low = SetFilePointer(mFile, 0, &High, FILE_CURRENT);
   if ( (Low==INVALID_SET_FILE_POINTER) && (GetLastError()!=NO_ERROR) )
-    return static_cast<uint64>(-1);
-  return ((uint64(High)<<32) | Low);
+    return static_cast<std::uint64_t>(-1);
+  return ((std::uint64_t(High)<<32) | Low);
 #endif
 }
 
-void WinIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
+void WinIOCallback::setFilePointer(std::int64_t Offset, seek_mode Mode)
 {
   DWORD Method;
   switch(Mode) {
@@ -242,13 +242,13 @@ void WinIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
   if ( mCurrentPosition == INVALID_SET_FILE_POINTER ) {
     High = 0;
     DWORD Low = SetFilePointer(mFile, 0, &High, FILE_CURRENT);
-    mCurrentPosition = ((uint64(High)<<32) | Low);
+    mCurrentPosition = ((std::uint64_t(High)<<32) | Low);
   } else {
-    mCurrentPosition |= uint64(High)<<32;
+    mCurrentPosition |= std::uint64_t(High)<<32;
   }
 }
 
-uint32 WinIOCallback::read(void*Buffer,size_t Size)
+std::uint32_t WinIOCallback::read(void*Buffer,std::size_t Size)
 {
   DWORD BytesRead;
   if (!ReadFile(mFile, Buffer, Size, &BytesRead, NULL)) {
@@ -258,7 +258,7 @@ uint32 WinIOCallback::read(void*Buffer,size_t Size)
   return BytesRead;
 }
 
-size_t WinIOCallback::write(const void*Buffer,size_t Size)
+std::size_t WinIOCallback::write(const void*Buffer,std::size_t Size)
 {
   DWORD BytesWriten;
   if (!WriteFile(mFile, Buffer, Size, &BytesWriten, NULL)) {

--- a/src/platform/win32/WinIOCallback.h
+++ b/src/platform/win32/WinIOCallback.h
@@ -53,10 +53,10 @@ public:
   bool open(const wchar_t* Path, const open_mode Mode, DWORD dwFlags=0);
   bool open(const char* Path, const open_mode Mode, DWORD dwFlags=0);
 
-  virtual uint32 read(void*Buffer,size_t Size);
-  virtual size_t write(const void*Buffer,size_t Size);
-  virtual void setFilePointer(int64 Offset,seek_mode Mode=seek_beginning);
-  virtual uint64 getFilePointer();
+  virtual std::uint32_t read(void*Buffer,std::size_t Size);
+  virtual std::size_t write(const void*Buffer,std::size_t Size);
+  virtual void setFilePointer(std::int64_t Offset,seek_mode Mode=seek_beginning);
+  virtual std::uint64_t getFilePointer();
   virtual void close();
 
   bool IsOk() { return mOk; };
@@ -65,7 +65,7 @@ public:
 protected:
   bool mOk;
   std::string mLastErrorStr;
-  uint64 mCurrentPosition;
+  std::uint64_t mCurrentPosition;
 
   HANDLE mFile;
 };


### PR DESCRIPTION
Since this is C++11 now, standard types can be used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>