### PR TITLE
add defaulted operator= constructor

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -61,6 +61,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
   public:
     EbmlBinary();
     EbmlBinary(const EbmlBinary & ElementToClone);
+    EbmlBinary& operator=(const EbmlBinary & ElementToClone);
     ~EbmlBinary() override;
 
     bool ValidateSize() const override {return IsFiniteSize() && GetSize() < 0x7FFFFFFF;} // we don't mind about what's inside

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -50,6 +50,13 @@ EbmlBinary::EbmlBinary()
 EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)
   :EbmlElement(ElementToClone)
 {
+  *this = ElementToClone;
+}
+
+EbmlBinary &
+EbmlBinary::operator=(const EbmlBinary & ElementToClone)
+{
+  free(Data);
   if (ElementToClone.Data == nullptr)
     Data = nullptr;
   else {
@@ -57,6 +64,7 @@ EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)
     if(Data != nullptr)
       memcpy(Data, ElementToClone.Data, GetSize());
   }
+  return *this;
 }
 
 EbmlBinary::~EbmlBinary() {


### PR DESCRIPTION
An implicit one is deprecated as of C++11 and gcc throws warnings.

Signed-off-by: Rosen Penev <rosenp@gmail.com>