### PR TITLE
initialize UnixEpochDelay in declaration

### DIFF
--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -92,7 +92,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 
     int64 myDate; ///< internal format of the date
 
-    static const uint64 UnixEpochDelay;
+    static const uint64 UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
 };
 
 END_LIBEBML_NAMESPACE

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -37,8 +37,6 @@
 
 START_LIBEBML_NAMESPACE
 
-const uint64 EbmlDate::UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
-
 EbmlDate::EbmlDate(const EbmlDate & ElementToClone)
 :EbmlElement(ElementToClone)
 {


### PR DESCRIPTION
Fixes a linking issue when trying to compile as a DLL on Windows.

Signed-off-by: Rosen Penev <rosenp@gmail.com>