### PR TITLE
CMakeLists: update to c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(ENABLE_WIN32_IO "Build the Windows I/O helper class" OFF)
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(libebml_SOURCES


### PR DESCRIPTION
MSVC 2022 no longer supports C++11. Fixes warning:

WARNING: msvc does not support C++11; attempting best effort; setting the standard to C++14