### PR TITLE
Use the libebml namespace explictly

### DIFF
--- a/ebml/Debug.h
+++ b/ebml/Debug.h
@@ -48,7 +48,7 @@
 
 #include "EbmlConfig.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 static const int MAX_PREFIX_LENGTH = 128;
 
@@ -165,6 +165,6 @@ extern ADbg globalDebug;
 #define EBML_ASSERT_NEW(p) assert(p!=0)
 #endif
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif

--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -49,7 +49,7 @@
 #endif //__BORLANDC__
 // ------------------------------------------------
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
     \class EbmlBinary
@@ -102,6 +102,6 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
     binary *Data; // the binary data inside the element
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_BINARY_H

--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -64,13 +64,8 @@
 #endif
 
 #define LIBEBML_NAMESPACE libebml
-#if defined(NO_NAMESPACE) // for older GCC
-# define START_LIBEBML_NAMESPACE
-# define END_LIBEBML_NAMESPACE
-#else // NO_NAMESPACE
-# define START_LIBEBML_NAMESPACE namespace LIBEBML_NAMESPACE {
-# define END_LIBEBML_NAMESPACE   }
-#endif // NO_NAMESPACE
+#define START_LIBEBML_NAMESPACE namespace LIBEBML_NAMESPACE {
+#define END_LIBEBML_NAMESPACE   }
 
 
 #ifndef countof

--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -39,7 +39,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 extern const EbmlSemanticContext EBML_DLL_API EbmlHead_Context;
 extern const EbmlSemanticContext EBML_DLL_API EVersion_Context;
@@ -55,6 +55,6 @@ extern const EbmlSemanticContext EBML_DLL_API EDocTypeReadVersion_Context;
 // global elements
 extern const EbmlSemanticContext EBML_DLL_API & GetEbmlGlobal_Context();
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_CONTEXTS_H

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -42,7 +42,7 @@
 #include "EbmlTypes.h"
 #include "EbmlBinary.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DECLARE_EBML_BINARY(EbmlCrc32)
   public:
@@ -137,6 +137,6 @@ inline bool IsAligned(const void *p, T * /* dummy */=nullptr)  // VC60 workaroun
   return IsAlignedOn(p, GetAlignment<T>());
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_CRC32_H

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -37,7 +37,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
     \class EbmlDate
@@ -95,6 +95,6 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
     static const uint64 UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_DATE_H

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -38,7 +38,7 @@
 
 #include "EbmlBinary.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class EBML_DLL_API EbmlDummy : public EbmlBinary {
   public:
@@ -64,6 +64,6 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
         EBML_CONCRETE_DUMMY_CLASS(EbmlDummy)
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_DUMMY_H

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -38,7 +38,7 @@
 #include "EbmlId.h"
 #include "IOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
   \brief The size of the EBML-coded length
@@ -509,6 +509,6 @@ class EBML_DLL_API EbmlElement {
     bool bLocked;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_ELEMENT_H

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -43,7 +43,7 @@
 
 #include "EbmlConfig.h" // contains _ENDIANESS_
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 enum endianess {
     big_endian,   ///< PowerPC, Alpha, 68000
@@ -117,6 +117,6 @@ template<class TYPE, endianess ENDIAN> class Endian
       }
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_ENDIAN_H

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -39,7 +39,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
     \class EbmlFloat
@@ -102,6 +102,6 @@ class EBML_DLL_API EbmlFloat : public EbmlElement {
     double DefaultValue;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_FLOAT_H

--- a/ebml/EbmlHead.h
+++ b/ebml/EbmlHead.h
@@ -39,7 +39,7 @@
 #include "EbmlTypes.h"
 #include "EbmlMaster.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DECLARE_EBML_MASTER(EbmlHead)
   public:
@@ -48,6 +48,6 @@ DECLARE_EBML_MASTER(EbmlHead)
         EBML_CONCRETE_CLASS(EbmlHead)
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_HEAD_H

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -38,7 +38,7 @@
 
 #include "EbmlTypes.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 
 #if defined(EBML_STRICT_API)
@@ -94,6 +94,6 @@ class EBML_DLL_API EbmlId {
     size_t Length;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_ID_H

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -48,7 +48,7 @@
 #define EBML_MASTER_RITERATOR std::vector<EbmlElement *>::reverse_iterator
 #define EBML_MASTER_CONST_RITERATOR std::vector<EbmlElement *>::const_reverse_iterator
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 const bool bChecksumUsedByDefault = false;
 
@@ -230,6 +230,6 @@ Type & AddNewChild(EbmlMaster & Master)
   return *(static_cast<Type *>(Master.AddNewElt(EBML_INFO(Type))));
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_MASTER_H

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -43,7 +43,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 const int DEFAULT_INT_SIZE = 1; ///< optimal size stored
 
@@ -96,6 +96,6 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
     int64 DefaultValue;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_SINTEGER_H

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -40,7 +40,7 @@
 #include "IOCallback.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
     \class EbmlStream
@@ -71,6 +71,6 @@ class EBML_DLL_API EbmlStream {
     IOCallback & Stream;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_STREAM_H

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -41,7 +41,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
     \class EbmlString
@@ -83,6 +83,6 @@ class EBML_DLL_API EbmlString : public EbmlElement {
     std::string DefaultValue;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_STRING_H

--- a/ebml/EbmlSubHead.h
+++ b/ebml/EbmlSubHead.h
@@ -41,7 +41,7 @@
 #include "EbmlUInteger.h"
 #include "EbmlString.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DECLARE_EBML_UINTEGER(EVersion)
   public:
@@ -92,6 +92,6 @@ DECLARE_EBML_UINTEGER(EDocTypeReadVersion)
         EBML_CONCRETE_CLASS(EDocTypeReadVersion)
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_SUBHEAD_H

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -37,7 +37,7 @@
 #include "ebml/EbmlConfig.h"
 #include "EbmlEndian.h" // binary needs to be defined
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 typedef wchar_t utf16;
 typedef uint32 utf32;
@@ -67,6 +67,6 @@ enum ScopeMode {
   SCOPE_NO_DATA
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -41,7 +41,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 const int DEFAULT_UINT_SIZE = 0; ///< optimal size stored
 
@@ -94,6 +94,6 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
     uint64 DefaultValue;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_UINTEGER_H

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -43,7 +43,7 @@
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
   \class UTFstring
@@ -135,6 +135,6 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElement {
     UTFstring DefaultValue;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_UNICODE_STRING_H

--- a/ebml/EbmlVersion.h
+++ b/ebml/EbmlVersion.h
@@ -40,7 +40,7 @@
 
 #include "EbmlConfig.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 #define LIBEBML_VERSION 0x010402
 
@@ -51,6 +51,6 @@ extern const EBML_DLL_API std::string EbmlCodeDate;
   \todo Closer relation between an element and the context it comes from (context is an element attribute ?)
 */
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_VERSION_H

--- a/ebml/EbmlVoid.h
+++ b/ebml/EbmlVoid.h
@@ -39,7 +39,7 @@
 #include "EbmlTypes.h"
 #include "EbmlBinary.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DECLARE_EBML_BINARY(EbmlVoid)
   public:
@@ -68,6 +68,6 @@ DECLARE_EBML_BINARY(EbmlVoid)
         EBML_CONCRETE_CLASS(EbmlVoid)
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_VOID_H

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -41,7 +41,7 @@
 // #include <iostream>
 
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 enum seek_mode
 {
@@ -112,6 +112,6 @@ template<class TRAITS> std::basic_ostream<char,TRAITS>&operator<<(std::basic_ost
 }
 */
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // MATROSKA_IOCALLBACK_H

--- a/ebml/MemIOCallback.h
+++ b/ebml/MemIOCallback.h
@@ -43,7 +43,7 @@
 #define stringstream strstream
 #endif
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class EBML_DLL_API MemIOCallback : public IOCallback
 {
@@ -113,6 +113,6 @@ protected:
   uint64 dataBufferMemorySize;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_MEMIOCALLBACK_H

--- a/ebml/MemReadIOCallback.h
+++ b/ebml/MemReadIOCallback.h
@@ -36,7 +36,7 @@
 #include "EbmlBinary.h"
 #include "IOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class EBML_DLL_API MemReadIOCallback : public IOCallback {
 protected:
@@ -60,6 +60,6 @@ protected:
   void Init(void const *Ptr, size_t Size);
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_MEMREADIOCALLBACK_H

--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -40,7 +40,7 @@
 #include "EbmlTypes.h"
 #include "IOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class EBML_DLL_API SafeReadIOCallback {
 public:
@@ -85,6 +85,6 @@ protected:
   void Init(IOCallback *IO, bool DeleteIO);
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif  // LIBEBML_SAFEREADIOCALLBACK_H

--- a/ebml/StdIOCallback.h
+++ b/ebml/StdIOCallback.h
@@ -45,7 +45,7 @@
 #endif //__BORLANDC__
 // ------------------------------------------------
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class EBML_DLL_API CRTError:public std::runtime_error
 {
@@ -96,6 +96,6 @@ class EBML_DLL_API StdIOCallback:public IOCallback
   virtual void close();
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -45,7 +45,7 @@
 
 #include "ebml/Debug.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class ADbg globalDebug;
 
@@ -237,4 +237,4 @@ bool ADbg::unsetDebugFile() {
 
 #endif // defined(LIBEBML_DEBUG)
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -40,7 +40,7 @@
 #include "ebml/EbmlBinary.h"
 #include "ebml/StdIOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlBinary::EbmlBinary()
   :EbmlElement(0, false), Data(nullptr)
@@ -109,4 +109,4 @@ bool EbmlBinary::operator==(const EbmlBinary & ElementToCompare) const
   return ((GetSize() == ElementToCompare.GetSize()) && (GetSize() == 0 || !memcmp(Data, ElementToCompare.Data, GetSize())));
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlContexts.cpp
+++ b/src/EbmlContexts.cpp
@@ -37,7 +37,7 @@
 #include "ebml/EbmlCrc32.h"
 #include "ebml/EbmlVoid.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 static const EbmlSemantic EbmlGlobal_ContextList[2] =
 {
@@ -54,4 +54,4 @@ const EbmlSemanticContext & GetEbmlGlobal_Context()
   return EbmlGlobal_Context;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -48,7 +48,7 @@ static constexpr uint32_t CRC32_SHIFTED(uint32_t c) { return c >> 8; }
 
 static constexpr uint32 CRC32_NEGL = 0xffffffffL;
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DEFINE_EBML_CLASS_GLOBAL(EbmlCrc32, 0xBF, 1, "EBMLCrc32\0ratamadabapa")
 
@@ -342,4 +342,4 @@ void EbmlCrc32::Finalize()
   SetValueIsSet();
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -35,7 +35,7 @@
 
 #include "ebml/EbmlDate.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlDate::EbmlDate(const EbmlDate & ElementToClone)
 :EbmlElement(ElementToClone)
@@ -86,4 +86,4 @@ bool EbmlDate::IsSmallerThan(const EbmlElement *Cmp) const
   return false;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -36,7 +36,7 @@
 #include "ebml/EbmlDummy.h"
 #include "ebml/EbmlContexts.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, 1, "DummyElement")
 
@@ -47,4 +47,4 @@ EbmlDummy::operator const EbmlId &()
   return DummyId;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -46,7 +46,7 @@
 #include "ebml/EbmlDummy.h"
 #include "ebml/EbmlContexts.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 /*!
   \todo handle more than CodedSize of 5
@@ -733,4 +733,4 @@ uint64 EbmlElement::VoidMe(IOCallback & output, bool bWithDefault)
   return Dummy.Overwrite(*this, output, true, bWithDefault);
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -38,7 +38,7 @@
 
 #include "ebml/EbmlFloat.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlFloat::EbmlFloat(const EbmlFloat::Precision prec)
   :EbmlElement(0, false)
@@ -154,4 +154,4 @@ bool EbmlFloat::IsSmallerThan(const EbmlElement *Cmp) const
   return false;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -37,7 +37,7 @@
 #include "ebml/EbmlSubHead.h"
 #include "ebml/EbmlContexts.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DEFINE_START_SEMANTIC(EbmlHead)
 DEFINE_SEMANTIC_ITEM(true, true, EVersion)        ///< EBMLVersion
@@ -55,4 +55,4 @@ EbmlHead::EbmlHead()
   :EbmlMaster(EbmlHead_Context)
 {}
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -42,7 +42,7 @@
 #include "ebml/EbmlContexts.h"
 #include "ebml/MemIOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlMaster::EbmlMaster(const EbmlSemanticContext & aContext, bool bSizeIsknown)
  :EbmlElement(0), Context(aContext), bChecksumUsed(bChecksumUsedByDefault)
@@ -566,4 +566,4 @@ bool EbmlMaster::InsertElement(EbmlElement & element, const EbmlElement & before
 }
 
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -53,7 +53,7 @@ ToSigned(uint64 u) {
 
 } // namespace
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlSInteger::EbmlSInteger()
   :EbmlElement(DEFAULT_INT_SIZE, false)
@@ -166,4 +166,4 @@ bool EbmlSInteger::IsSmallerThan(const EbmlElement *Cmp) const
   return false;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlStream.cpp
+++ b/src/EbmlStream.cpp
@@ -35,7 +35,7 @@
 */
 #include "ebml/EbmlStream.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlStream::EbmlStream(IOCallback & DataStream)
   :Stream(DataStream)
@@ -51,4 +51,4 @@ EbmlElement * EbmlStream::FindNextElement(const EbmlSemanticContext & Context, i
   return EbmlElement::FindNextElement(Stream, Context, UpperLevel, MaxDataSize, AllowDummyElt, MaxLowerLevel);
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -38,7 +38,7 @@
 
 #include "ebml/EbmlString.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlString::EbmlString()
   :EbmlElement(0, false)
@@ -163,4 +163,4 @@ filepos_t EbmlString::ReadData(IOCallback & input, ScopeMode ReadFully)
   return GetSize();
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlSubHead.cpp
+++ b/src/EbmlSubHead.cpp
@@ -36,7 +36,7 @@
 #include "ebml/EbmlSubHead.h"
 #include "ebml/EbmlContexts.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, 2, EbmlHead, "EBMLVersion", 1)
 DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, 2, EbmlHead, "EBMLReadVersion", 1)
@@ -46,4 +46,4 @@ DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, 2, EbmlHead, "EBMLDocType"
 DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, 2, EbmlHead, "EBMLDocTypeVersion", 1)
 DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, 2, EbmlHead, "EBMLDocTypeReadVersion", 1)
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -38,7 +38,7 @@
 
 #include "ebml/EbmlUInteger.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 EbmlUInteger::EbmlUInteger()
   :EbmlElement(DEFAULT_UINT_SIZE, false)
@@ -157,4 +157,4 @@ bool EbmlUInteger::IsSmallerThan(const EbmlElement *Cmp) const
   return false;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -42,7 +42,7 @@
 
 #include "lib/utf8-cpp/source/utf8/checked.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 // ===================== UTFstring class ===================
 
@@ -329,4 +329,4 @@ filepos_t EbmlUnicodeString::ReadData(IOCallback & input, ScopeMode ReadFully)
   return GetSize();
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlVersion.cpp
+++ b/src/EbmlVersion.cpp
@@ -36,7 +36,7 @@
 
 #include "ebml/EbmlVersion.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 const std::string EbmlCodeVersion = "1.4.2";
 
@@ -45,4 +45,4 @@ const std::string EbmlCodeVersion = "1.4.2";
 // remain API compatible.
 const std::string EbmlCodeDate = "Unknown";
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -36,7 +36,7 @@
 #include "ebml/EbmlVoid.h"
 #include "ebml/EbmlContexts.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 DEFINE_EBML_CLASS_GLOBAL(EbmlVoid, 0xEC, 1, "EBMLVoid")
 
@@ -134,4 +134,4 @@ uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, b
   return EltToVoid.GetSize() + EltToVoid.HeadSize();
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -40,7 +40,7 @@
 
 using namespace std;
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 void IOCallback::writeFully(const void*Buffer,size_t Size)
 {
@@ -71,4 +71,4 @@ void IOCallback::readFully(void*Buffer,size_t Size)
   }
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -36,7 +36,7 @@
 #include "ebml/Debug.h"
 #include "ebml/EbmlConfig.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 MemIOCallback::MemIOCallback(uint64 DefaultSize)
 {
@@ -118,4 +118,4 @@ uint32 MemIOCallback::write(IOCallback & IOToRead, size_t Size)
   return Size;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/MemReadIOCallback.cpp
+++ b/src/MemReadIOCallback.cpp
@@ -39,7 +39,7 @@
 #include "ebml/EbmlBinary.h"
 #include "ebml/MemReadIOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 MemReadIOCallback::MemReadIOCallback(void const *Ptr,
                                      size_t Size) {
@@ -86,4 +86,4 @@ MemReadIOCallback::setFilePointer(int64 Offset,
   mPtr = mStart + NewPosition;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -40,7 +40,7 @@
 #include "ebml/MemReadIOCallback.h"
 #include "ebml/SafeReadIOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 SafeReadIOCallback::EndOfStreamX::EndOfStreamX(size_t MissingBytes)
   : mMissingBytes(MissingBytes)
@@ -171,4 +171,4 @@ SafeReadIOCallback::Read(void *Dst,
     throw SafeReadIOCallback::EndOfStreamX(Count - NumRead);
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -43,7 +43,7 @@
 
 using namespace std;
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 CRTError::CRTError(int nError, const std::string & Description)
   :std::runtime_error(Description+": "+strerror(nError))
@@ -179,4 +179,4 @@ void StdIOCallback::close()
   File=nullptr;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/platform/win32/WinIOCallback.cpp
+++ b/src/platform/win32/WinIOCallback.cpp
@@ -44,7 +44,7 @@
 #define INVALID_SET_FILE_POINTER ((DWORD)-1)
 #endif // INVALID_SET_FILE_POINTER
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 WinIOCallback::WinIOCallback(const char* Path, const open_mode aMode, DWORD dwFlags)
   :mFile(NULL), mOk(false)
@@ -273,4 +273,4 @@ bool WinIOCallback::SetEOF()
   return SetEndOfFile(mFile) != 0;
 }
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml

--- a/src/platform/win32/WinIOCallback.h
+++ b/src/platform/win32/WinIOCallback.h
@@ -41,7 +41,7 @@
 #include <string>
 #include "ebml/IOCallback.h"
 
-START_LIBEBML_NAMESPACE
+namespace libebml {
 
 class WinIOCallback: public IOCallback
 {
@@ -70,6 +70,6 @@ protected:
   HANDLE mFile;
 };
 
-END_LIBEBML_NAMESPACE
+} // namespace libebml
 
 #endif // LIBEBML_WINIOCALLBACK_H


### PR DESCRIPTION
No need to hide it behind a macro anymore. It's more readable for users.

The macros are kept for compatibility with existing code.