### PR TITLE
Fix misc MSVC warnings

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -433,7 +433,7 @@ class EBML_DLL_API EbmlElement {
     virtual bool IsDummy() const {return false;}
     virtual bool IsMaster() const {return false;}
 
-    uint8 HeadSize() const {
+    size_t HeadSize() const {
       return EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
     } /// return the size of the head, on reading/writing
 

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -35,6 +35,7 @@
   \author Julien Coloos  <suiryc @ users.sf.net>
 */
 #include <cassert>
+#include <limits>
 #include <string>
 
 #include "ebml/EbmlBinary.h"
@@ -97,7 +98,7 @@ filepos_t EbmlBinary::ReadData(IOCallback & input, ScopeMode ReadFully)
     return 0;
   }
 
-  Data = (GetSize() < SIZE_MAX) ? static_cast<binary *>(malloc(GetSize())) : nullptr;
+  Data = (GetSize() < std::numeric_limits<size_t>::max()) ? static_cast<binary *>(malloc(GetSize())) : nullptr;
   if (Data == nullptr)
     throw CRTError(std::string("Error allocating data"));
   SetValueIsSet();

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -616,7 +616,7 @@ filepos_t EbmlElement::RenderHead(IOCallback & output, bool bForceRender, bool b
 filepos_t EbmlElement::MakeRenderHead(IOCallback & output, bool bKeepPosition)
 {
   std::array<binary, 4 + 8> FinalHead; // Class D + 64 bits coded size
-  unsigned int FinalHeadSize;
+  size_t FinalHeadSize;
 
   FinalHeadSize = EBML_ID_LENGTH((const EbmlId&)*this);
   EbmlId(*this).Fill(FinalHead.data());

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -35,6 +35,7 @@
 #include <array>
 #include <cassert>
 #include <limits>
+#include <cstdint>
 
 #include "ebml/EbmlSInteger.h"
 
@@ -110,16 +111,16 @@ uint64 EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
     SetSize_(2);
   } else if (Value <= 0x7FFFFF && Value >= (-0x800000)) {
     SetSize_(3);
-  } else if (Value <= EBML_PRETTYLONGINT(0x7FFFFFFF) && Value >= (EBML_PRETTYLONGINT(-0x80000000))) {
+  } else if (Value <= INT64_C(0x7FFFFFFF) && Value >= (INT64_C(-0x80000000))) {
     SetSize_(4);
-  } else if (Value <= EBML_PRETTYLONGINT(0x7FFFFFFFFF) &&
-             Value >= EBML_PRETTYLONGINT(-0x8000000000)) {
+  } else if (Value <= INT64_C(0x7FFFFFFFFF) &&
+             Value >= INT64_C(-0x8000000000)) {
     SetSize_(5);
-  } else if (Value <= EBML_PRETTYLONGINT(0x7FFFFFFFFFFF) &&
-             Value >= EBML_PRETTYLONGINT(-0x800000000000)) {
+  } else if (Value <= INT64_C(0x7FFFFFFFFFFF) &&
+             Value >= INT64_C(-0x800000000000)) {
     SetSize_(6);
-  } else if (Value <= EBML_PRETTYLONGINT(0x7FFFFFFFFFFFFF) &&
-             Value >= EBML_PRETTYLONGINT(-0x80000000000000)) {
+  } else if (Value <= INT64_C(0x7FFFFFFFFFFFFF) &&
+             Value >= INT64_C(-0x80000000000000)) {
     SetSize_(7);
   } else {
     SetSize_(8);

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -222,7 +222,7 @@ const UTFstring & EbmlUnicodeString::DefaultVal() const
 */
 filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
 {
-  uint32 Result = Value.GetUTF8().length();
+  size_t Result = Value.GetUTF8().length();
 
   if (Result != 0) {
     output.writeFully(Value.GetUTF8().c_str(), Result);

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -80,9 +80,9 @@ uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output
     // fill the rest with another void element
     EbmlVoid aTmp;
     aTmp.SetSize_(HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize() - 1); // 1 is the length of the Void ID
-    const int HeadBefore = aTmp.HeadSize();
+    const size_t HeadBefore = aTmp.HeadSize();
     aTmp.SetSize_(aTmp.GetSize() - CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength(), aTmp.IsFiniteSize()));
-    const int HeadAfter = aTmp.HeadSize();
+    const size_t HeadAfter = aTmp.HeadSize();
     if (HeadBefore != HeadAfter) {
       aTmp.SetSizeLength(CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength(), aTmp.IsFiniteSize()) - (HeadAfter - HeadBefore));
     }

--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -33,6 +33,7 @@
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
 
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -64,10 +65,17 @@ void IOCallback::readFully(void*Buffer,size_t Size)
   if(Buffer == nullptr)
     throw;
 
-  if(read(Buffer,Size) != Size) {
-    stringstream Msg;
-    Msg<<"EOF in readFully("<<Buffer<<","<<Size<<")";
-    throw runtime_error(Msg.str());
+  char *readBuf = static_cast<char *>(Buffer);
+  uint32_t readSize = static_cast<uint32_t>(std::min<size_t>(std::numeric_limits<uint32>::max(), Size));
+  while (readSize != 0) {
+    if(read(readBuf,readSize) != readSize) {
+      stringstream Msg;
+      Msg<<"EOF in readFully("<<Buffer<<","<<Size<<")";
+      throw runtime_error(Msg.str());
+    }
+    Size -= readSize;
+    readBuf += readSize;
+    readSize = static_cast<uint32_t>(std::min<size_t>(std::numeric_limits<uint32>::max(), Size));
   }
 }
 

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -121,22 +121,22 @@ SafeReadIOCallback::GetUIntBE(size_t NumBytes) {
 
 uint8
 SafeReadIOCallback::GetUInt8() {
-  return GetUIntBE(1);
+  return static_cast<uint8>(GetUIntBE(1));
 }
 
 uint16
 SafeReadIOCallback::GetUInt16BE() {
-  return GetUIntBE(2);
+  return static_cast<uint16>(GetUIntBE(2));
 }
 
 uint32
 SafeReadIOCallback::GetUInt24BE() {
-  return GetUIntBE(3);
+  return static_cast<uint32>(GetUIntBE(3));
 }
 
 uint32
 SafeReadIOCallback::GetUInt32BE() {
-  return GetUIntBE(4);
+  return static_cast<uint32>(GetUIntBE(4));
 }
 
 uint64

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -34,7 +34,7 @@
 */
 
 #include <cassert>
-#include <climits>
+#include <limits>
 #include <sstream>
 
 #include "ebml/StdIOCallback.h"
@@ -117,8 +117,8 @@ void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
     assert(Offset >= numeric_limits<long>::min());
   */
 
-  assert(Offset <= LONG_MAX);
-  assert(Offset >= LONG_MIN);
+  assert(Offset <= std::numeric_limits<long>::max());
+  assert(Offset >= std::numeric_limits<long>::min());
 
   assert(Mode==SEEK_CUR||Mode==SEEK_END||Mode==SEEK_SET);
 


### PR DESCRIPTION
The `EbmlElement: use size_t for HeadSize()` is breaking API and ABI. Since we're breaking ABI in 1.5.0 that should be OK.

Ref. #105 