### PR TITLE
change return type of IOCallback::read() to size_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 
-project(ebml VERSION 1.5.0)
+project(ebml VERSION 2.0.0)
 
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Version 1.5.0 2022-??-??
 
+* API break: the function `IOCallback::read()` now returns a `size_t`
+  instead of a `uint32`. This fixes the limitation that the function
+  couldn't signal success properly if the number of bytes to read
+  exceeded 4 GB.
 * Bumped the library's soname to 6 due to ABI breaking changes that
   already happened in 1.4.3.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Version 1.5.0 2022-??-??
+# Version 2.0.0 2022-??-??
 
 * API break: the function `IOCallback::read()` now returns a `size_t`
   instead of a `uint32`. This fixes the limitation that the function

--- a/ebml/EbmlVersion.h
+++ b/ebml/EbmlVersion.h
@@ -42,7 +42,7 @@
 
 namespace libebml {
 
-#define LIBEBML_VERSION 0x010500
+#define LIBEBML_VERSION 0x020000
 
 extern const EBML_DLL_API std::string EbmlCodeVersion;
 extern const EBML_DLL_API std::string EbmlCodeDate;

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -59,7 +59,7 @@ public:
   // file, the buffer and the size and the function returns the bytes read.
   // If an error occurs or the file pointer points to the end of the file 0 is returned.
   // Users are encouraged to throw a descriptive exception, when an error occurs.
-  virtual uint32 read(void*Buffer,size_t Size)=0;
+  virtual size_t read(void*Buffer,size_t Size)=0;
 
   // Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
   // or SEEK_END. The callback should return true(1) if the seek operation succeeded

--- a/ebml/MemIOCallback.h
+++ b/ebml/MemIOCallback.h
@@ -54,7 +54,7 @@ public:
   /*!
     Use this to copy some data to the Buffer from this classes data
   */
-  uint32 read(void *Buffer, size_t Size) override;
+  size_t read(void *Buffer, size_t Size) override;
 
   /*!
     Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR

--- a/ebml/MemReadIOCallback.h
+++ b/ebml/MemReadIOCallback.h
@@ -48,7 +48,7 @@ public:
   MemReadIOCallback(MemReadIOCallback const &Mem);
   ~MemReadIOCallback() override = default;
 
-  uint32 read(void *Buffer, size_t Size) override;
+  size_t read(void *Buffer, size_t Size) override;
   void setFilePointer(int64 Offset, seek_mode Mode = seek_beginning) override;
   size_t write(void const *, size_t) override { return 0; }
   uint64 getFilePointer() override { return mPtr - mStart; }

--- a/ebml/StdIOCallback.h
+++ b/ebml/StdIOCallback.h
@@ -73,7 +73,7 @@ class EBML_DLL_API StdIOCallback:public IOCallback
   StdIOCallback(const char*Path, open_mode Mode);
   ~StdIOCallback() noexcept override;
 
-  uint32 read(void*Buffer,size_t Size) override;
+  size_t read(void*Buffer,size_t Size) override;
 
   // Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
   // or SEEK_END. The callback should return true(1) if the seek operation succeeded

--- a/src/EbmlVersion.cpp
+++ b/src/EbmlVersion.cpp
@@ -38,7 +38,7 @@
 
 namespace libebml {
 
-const std::string EbmlCodeVersion = "1.5.0";
+const std::string EbmlCodeVersion = "2.0.0";
 
 // Up to version 1.3.3 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -63,7 +63,7 @@ MemIOCallback::~MemIOCallback()
     free(dataBuffer);
 }
 
-uint32 MemIOCallback::read(void *Buffer, size_t Size)
+size_t MemIOCallback::read(void *Buffer, size_t Size)
 {
   if (Buffer == nullptr || Size < 1)
     return 0;

--- a/src/MemReadIOCallback.cpp
+++ b/src/MemReadIOCallback.cpp
@@ -62,7 +62,7 @@ MemReadIOCallback::Init(void const *Ptr,
   mPtr   = mStart;
 }
 
-uint32
+size_t
 MemReadIOCallback::read(void *Buffer,
                         size_t Size) {
   const size_t RemainingBytes = mEnd - mPtr;

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -97,7 +97,7 @@ StdIOCallback::~StdIOCallback() noexcept
 
 
 
-uint32 StdIOCallback::read(void*Buffer,size_t Size)
+size_t StdIOCallback::read(void*Buffer,size_t Size)
 {
   assert(File!=nullptr);
 


### PR DESCRIPTION
Fixes #108.

The function is supposed to return the number of bytes actually read. As it takes a "number of bytes to read" parameter of type `size_t`, it cannot signal success properly if the number of bytes to read exceeds the size of its former return type, `uint32`, which is 4 GB.

This breaks the API & the ABI. Users of this class hierarchy have to adjust their overrides as well.