### PR TITLE
V1.4.4 fix abi breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 
-project(ebml VERSION 1.4.3)
+project(ebml VERSION 1.4.4)
 
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Version 1.4.4 2022-10-05
+
+* Fix ABI compatibility: unfortunately release 1.4.3 broke ABI
+  compatibility. This release restores the compatibility with release
+  1.4.2. Please use it instead of release 1.4.3. Fixes #104.
+
 # Version 1.4.3 2022-09-30
 
 * A C++14 compliant C++ compiler is now required.

--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -99,7 +99,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
 #else
   protected:
 #endif
-    binary *Data{nullptr}; // the binary data inside the element
+    binary *Data; // the binary data inside the element
 };
 
 } // namespace libebml

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -45,7 +45,7 @@ namespace libebml {
 */
 class EBML_DLL_API EbmlDate : public EbmlElement {
   public:
-    EbmlDate() :EbmlElement(8, false) {}
+    EbmlDate() :EbmlElement(8, false), myDate(0) {}
     EbmlDate(const EbmlDate & ElementToClone);
 
     /*!
@@ -90,7 +90,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 #endif
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
 
-    int64 myDate{0}; ///< internal format of the date
+    int64 myDate; ///< internal format of the date
 
     static const uint64 UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
 };

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -92,7 +92,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 
     int64 myDate; ///< internal format of the date
 
-    static const uint64 UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
+    static const uint64 UnixEpochDelay;
 };
 
 } // namespace libebml

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -500,13 +500,13 @@ class EBML_DLL_API EbmlElement {
 #endif
     uint64 Size;        ///< the size of the data to write
     uint64 DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
-    int SizeLength{0}; /// the minimum size on which the size will be written (0 = optimal)
-    bool bSizeIsFinite{true};
-    uint64 ElementPosition{0};
-    uint64 SizePosition{0};
+    int SizeLength; /// the minimum size on which the size will be written (0 = optimal)
+    bool bSizeIsFinite;
+    uint64 ElementPosition;
+    uint64 SizePosition;
     bool bValueIsSet;
-    bool DefaultIsSet{false};
-    bool bLocked{false};
+    bool DefaultIsSet;
+    bool bLocked;
 };
 
 } // namespace libebml

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -54,7 +54,7 @@ class EBML_DLL_API UTFstring {
 public:
   using value_type = wchar_t;
 
-  UTFstring() = default;
+  UTFstring();
   UTFstring(const wchar_t *); // should be NULL terminated
   UTFstring(const UTFstring &);
   UTFstring(std::wstring const &);
@@ -83,8 +83,8 @@ public:
 #else
     protected:
 #endif
-  size_t _Length{0}; ///< length of the UCS string excluding the \0
-  wchar_t* _Data{nullptr}; ///< internal UCS representation
+  size_t _Length; ///< length of the UCS string excluding the \0
+  wchar_t* _Data; ///< internal UCS representation
   std::string UTF8string;
   static bool wcscmp_internal(const wchar_t *str1, const wchar_t *str2);
   void UpdateFromUTF8();

--- a/ebml/EbmlVersion.h
+++ b/ebml/EbmlVersion.h
@@ -42,7 +42,7 @@
 
 namespace libebml {
 
-#define LIBEBML_VERSION 0x010403
+#define LIBEBML_VERSION 0x010404
 
 extern const EBML_DLL_API std::string EbmlCodeVersion;
 extern const EBML_DLL_API std::string EbmlCodeDate;

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -43,7 +43,7 @@
 namespace libebml {
 
 EbmlBinary::EbmlBinary()
-  :EbmlElement(0, false) 
+  :EbmlElement(0, false), Data(nullptr)
 {}
 
 EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -37,6 +37,8 @@
 
 namespace libebml {
 
+const uint64 EbmlDate::UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
+
 EbmlDate::EbmlDate(const EbmlDate & ElementToClone)
 :EbmlElement(ElementToClone)
 {

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -234,7 +234,13 @@ const EbmlSemantic & EbmlSemanticContext::GetSemantic(size_t i) const
 
 EbmlElement::EbmlElement(uint64 aDefaultSize, bool bValueSet)
   :DefaultSize(aDefaultSize)
-  , bValueIsSet(bValueSet)
+  ,SizeLength(0) ///< write optimal size by default
+  ,bSizeIsFinite(true)
+  ,ElementPosition(0)
+  ,SizePosition(0)
+  ,bValueIsSet(bValueSet)
+  ,DefaultIsSet(false)
+  ,bLocked(false)
 {
   Size = DefaultSize;
 }

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -46,12 +46,21 @@ namespace libebml {
 
 // ===================== UTFstring class ===================
 
+UTFstring::UTFstring()
+  :_Length(0)
+  ,_Data(nullptr)
+{}
+
 UTFstring::UTFstring(const wchar_t * _aBuf)
+  :_Length(0)
+  ,_Data(nullptr)
 {
   *this = _aBuf;
 }
 
 UTFstring::UTFstring(std::wstring const &_aBuf)
+  :_Length(0)
+  ,_Data(nullptr)
 {
   *this = _aBuf.c_str();
 }
@@ -62,6 +71,8 @@ UTFstring::~UTFstring()
 }
 
 UTFstring::UTFstring(const UTFstring & _aBuf)
+  :_Length(0)
+  ,_Data(nullptr)
 {
   *this = _aBuf.c_str();
 }

--- a/src/EbmlVersion.cpp
+++ b/src/EbmlVersion.cpp
@@ -38,7 +38,7 @@
 
 namespace libebml {
 
-const std::string EbmlCodeVersion = "1.4.3";
+const std::string EbmlCodeVersion = "1.4.4";
 
 // Up to version 1.3.3 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to


### PR DESCRIPTION
Reverting these commits on top of release 1.4.3 fixes the ABI breakage. Tests were done with the tool `abidiff` from `libabigail`.

The goal is to release a version 1.4.4 that's basically just 1.4.3 without the ABI breakage so that distributions can update their packages while we continue working on the API-breaking 2.0.0.

See #104.

I haven't tested this yet against a packaged MKVToolNix that was compiled with 1.4.2; therefore please don't merge yet.

Will do the same thing for libMatroska.