### PR TITLE
use the utf-8 C++ library as an external (header-only) library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ if(MSVC)
   target_compile_definitions(ebml PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
+add_subdirectory(src/lib/utf8-cpp)
+target_link_libraries(ebml PRIVATE $<BUILD_INTERFACE:utf8-cpp>)
+
 include(GenerateExportHeader)
 generate_export_header(ebml EXPORT_MACRO_NAME EBML_DLL_API)
 target_sources(ebml

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -40,7 +40,7 @@
 
 #include "ebml/EbmlUnicodeString.h"
 
-#include "lib/utf8-cpp/source/utf8/checked.h"
+#include <utf8/checked.h>
 
 namespace libebml {
 

--- a/src/lib/utf8-cpp/CMakeLists.txt
+++ b/src/lib/utf8-cpp/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(utf8-cpp INTERFACE)
+
+target_include_directories(utf8-cpp INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/source)
+target_sources(utf8-cpp INTERFACE 
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/utf8/checked.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/utf8/core.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/utf8/cpp11.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/utf8/cpp17.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/utf8/checked.h
+)


### PR DESCRIPTION
It might be used as an external package someday. For it's a CMake interface since it's a header only piece of code.