### PR TITLE
remove cargo culting of config.h

### DIFF
--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -36,10 +36,6 @@
 #ifndef LIBEBML_CONFIG_H
 #define LIBEBML_CONFIG_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "ebml_export.h"
 
 #if defined(__linux__)


### PR DESCRIPTION
We do not have a config.h file and it should not be in a public header.

`config.h` and `HAVE_CONFIG_H` is usually used during the build phase.