### PR TITLE
move the countof() helper in EbmlElement where it's used

### DIFF
--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -68,11 +68,6 @@
 #define END_LIBEBML_NAMESPACE   }
 
 
-#ifndef countof
-#define countof(x) (sizeof(x)/sizeof((x)[0]))
-#endif
-
-
 // The LIBEBML_DEBUG symbol is defined, when we are creating a debug build. In this
 // case the debug logging code is compiled in.
 #if (defined(DEBUG)||defined(_DEBUG)) && !defined(LIBEBML_DEBUG)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -40,6 +40,12 @@
 
 namespace libebml {
 
+template <typename T, std::size_t N>
+constexpr std::size_t countof(T const (&)[N]) noexcept
+{
+    return N;
+}
+
 /*!
   \brief The size of the EBML-coded length
 */


### PR DESCRIPTION
And use a cleaner C++ version. Now it's part of the libebml namespace so it's not mixed with other implementations.