### PR TITLE
Misc endian cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,14 @@ if(MSVC)
   target_compile_definitions(ebml PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
+include(TestBigEndian)
+test_big_endian(BUILD_BIG_ENDIAN)
+if(BUILD_BIG_ENDIAN)
+  target_compile_definitions(ebml PRIVATE BUILD_BIG_ENDIAN)
+else()
+  target_compile_definitions(ebml PRIVATE BUILD_LITTLE_ENDIAN)
+endif()
+
 include(GenerateExportHeader)
 generate_export_header(ebml EXPORT_MACRO_NAME EBML_DLL_API)
 target_sources(ebml

--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -42,34 +42,6 @@
 
 #include "ebml_export.h"
 
-#if defined(__linux__)
-#include <endian.h>
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-#undef WORDS_BIGENDIAN
-#elif __BYTE_ORDER == __BIG_ENDIAN
-#define WORDS_BIGENDIAN 1
-#endif
-#else // !LINUX
-// automatic endianess detection working on GCC
-#if !defined(WORDS_BIGENDIAN)
-#if (defined (__arm__) && ! defined (__ARMEB__)) || defined (__i386__) || defined (__i860__) || defined (__ns32000__) || defined (__vax__) || defined (__amd64__) || defined (__x86_64__)
-#undef WORDS_BIGENDIAN
-#elif defined (__sparc__) || defined (__alpha__) || defined (__PPC__) || defined (__mips__) || defined (__ppc__) || defined (__BIG_ENDIAN__)
-#define WORDS_BIGENDIAN 1
-#else // other CPU
-// not automatically detected, put it yourself
-#undef WORDS_BIGENDIAN // for my testing platform (x86)
-#endif
-#endif // not autoconf
-#endif
-
-#if defined(WORDS_BIGENDIAN) && defined(BUILD_LITTLE_ENDIAN)
-#error mismatching endianess between C++ compiler anc CMake
-#endif
-#if !defined(WORDS_BIGENDIAN) && defined(BUILD_BIG_ENDIAN)
-#error mismatching endianess between C++ compiler anc CMake
-#endif
-
 #define LIBEBML_NAMESPACE libebml
 #define START_LIBEBML_NAMESPACE namespace LIBEBML_NAMESPACE {
 #define END_LIBEBML_NAMESPACE   }

--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -49,18 +49,25 @@
 #elif __BYTE_ORDER == __BIG_ENDIAN
 #define WORDS_BIGENDIAN 1
 #endif
-#else
+#else // !LINUX
 // automatic endianess detection working on GCC
 #if !defined(WORDS_BIGENDIAN)
 #if (defined (__arm__) && ! defined (__ARMEB__)) || defined (__i386__) || defined (__i860__) || defined (__ns32000__) || defined (__vax__) || defined (__amd64__) || defined (__x86_64__)
 #undef WORDS_BIGENDIAN
 #elif defined (__sparc__) || defined (__alpha__) || defined (__PPC__) || defined (__mips__) || defined (__ppc__) || defined (__BIG_ENDIAN__)
 #define WORDS_BIGENDIAN 1
-#else
+#else // other CPU
 // not automatically detected, put it yourself
 #undef WORDS_BIGENDIAN // for my testing platform (x86)
 #endif
 #endif // not autoconf
+#endif
+
+#if defined(WORDS_BIGENDIAN) && defined(BUILD_LITTLE_ENDIAN)
+#error mismatching endianess between C++ compiler anc CMake
+#endif
+#if !defined(WORDS_BIGENDIAN) && defined(BUILD_BIG_ENDIAN)
+#error mismatching endianess between C++ compiler anc CMake
 #endif
 
 #define LIBEBML_NAMESPACE libebml

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -43,6 +43,34 @@
 
 #include "EbmlConfig.h" // contains _ENDIANESS_
 
+#if defined(__linux__)
+#include <endian.h>
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#undef WORDS_BIGENDIAN
+#elif __BYTE_ORDER == __BIG_ENDIAN
+#define WORDS_BIGENDIAN 1
+#endif
+#else // !LINUX
+// automatic endianess detection working on GCC
+#if !defined(WORDS_BIGENDIAN)
+#if (defined (__arm__) && ! defined (__ARMEB__)) || defined (__i386__) || defined (__i860__) || defined (__ns32000__) || defined (__vax__) || defined (__amd64__) || defined (__x86_64__)
+#undef WORDS_BIGENDIAN
+#elif defined (__sparc__) || defined (__alpha__) || defined (__PPC__) || defined (__mips__) || defined (__ppc__) || defined (__BIG_ENDIAN__)
+#define WORDS_BIGENDIAN 1
+#else // other CPU
+// not automatically detected, put it yourself
+#undef WORDS_BIGENDIAN // for my testing platform (x86)
+#endif
+#endif // not autoconf
+#endif
+
+#if defined(WORDS_BIGENDIAN) && defined(BUILD_LITTLE_ENDIAN)
+#error mismatching endianess between C++ compiler anc CMake
+#endif
+#if !defined(WORDS_BIGENDIAN) && defined(BUILD_BIG_ENDIAN)
+#error mismatching endianess between C++ compiler anc CMake
+#endif
+
 namespace libebml {
 
 enum endianess {

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -145,6 +145,19 @@ template<class TYPE, endianess ENDIAN> class Endian
       }
 };
 
+using lil_int16 = Endian<std::int16_t, little_endian>;
+using lil_int32 = Endian<std::int32_t, little_endian>;
+using lil_int64 = Endian<std::int64_t, little_endian>;
+using lil_uint16 = Endian<std::uint16_t, little_endian>;
+using lil_uint32 = Endian<std::uint32_t, little_endian>;
+using lil_uint64 = Endian<std::uint64_t, little_endian>;
+using big_int16 = Endian<std::int16_t, big_endian>;
+using big_int32 = Endian<std::int32_t, big_endian>;
+using big_int64 = Endian<std::int64_t, big_endian>;
+using big_uint16 = Endian<std::uint16_t, big_endian>;
+using big_uint32 = Endian<std::uint32_t, big_endian>;
+using big_uint64 = Endian<std::uint64_t, big_endian>;
+
 } // namespace libebml
 
 #endif // LIBEBML_ENDIAN_H

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -145,12 +145,6 @@ template<class TYPE, endianess ENDIAN> class Endian
       }
 };
 
-using lil_int16 = Endian<std::int16_t, little_endian>;
-using lil_int32 = Endian<std::int32_t, little_endian>;
-using lil_int64 = Endian<std::int64_t, little_endian>;
-using lil_uint16 = Endian<std::uint16_t, little_endian>;
-using lil_uint32 = Endian<std::uint32_t, little_endian>;
-using lil_uint64 = Endian<std::uint64_t, little_endian>;
 using big_int16 = Endian<std::int16_t, big_endian>;
 using big_int32 = Endian<std::int32_t, big_endian>;
 using big_int64 = Endian<std::int64_t, big_endian>;

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -65,18 +65,6 @@ using utf8 = char;
 
 using bits80 = binary[10];
 
-using lil_int16 = Endian<std::int16_t, little_endian>;
-using lil_int32 = Endian<std::int32_t, little_endian>;
-using lil_int64 = Endian<std::int64_t, little_endian>;
-using lil_uint16 = Endian<std::uint16_t, little_endian>;
-using lil_uint32 = Endian<std::uint32_t, little_endian>;
-using lil_uint64 = Endian<std::uint64_t, little_endian>;
-using big_int16 = Endian<std::int16_t, big_endian>;
-using big_int32 = Endian<std::int32_t, big_endian>;
-using big_int64 = Endian<std::int64_t, big_endian>;
-using big_uint16 = Endian<std::uint16_t, big_endian>;
-using big_uint32 = Endian<std::uint32_t, big_endian>;
-using big_uint64 = Endian<std::uint64_t, big_endian>;
 using checksum = Endian<std::uint32_t, big_endian>;
 using big_80bits = Endian<bits80, big_endian>;
 

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -63,12 +63,6 @@ using utf16 = wchar_t;
 using utf32 = std::uint32_t;
 using utf8 = char;
 
-using bits80 = binary[10];
-
-using checksum = Endian<std::uint32_t, big_endian>;
-using big_80bits = Endian<bits80, big_endian>;
-
-
 enum ScopeMode {
   SCOPE_PARTIAL_DATA = 0,
   SCOPE_ALL_DATA,

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -35,6 +35,7 @@
   \author Jory Stone       <jcsston @ toughguy.net>
 */
 #include "ebml/EbmlCrc32.h"
+#include "ebml/EbmlEndian.h"
 #include "ebml/EbmlContexts.h"
 #include "ebml/MemIOCallback.h"
 


### PR DESCRIPTION
All endianess related code is moved into `EbmlEndian.h`

Ony the big endian templates are kept as we don't use the little endian ones. But people can still use the little endian implementation if they want. The implementation is not changed although it is likely inefficient compared to compiler built-in helpers. We could completely redo the big_xxx types in more efficient way and forget about other sizes.

Fixes #122 