### PR TITLE
Use proper integer literal and remove EBML_PRETTYLONGINT

### DIFF
--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -86,10 +86,4 @@
 # endif
 #endif
 
-#ifdef __GNUC__
-#define EBML_PRETTYLONGINT(c) (c ## ll)
-#else // __GNUC__
-#define EBML_PRETTYLONGINT(c) (c)
-#endif // __GNUC__
-
 #endif // LIBEBML_CONFIG_H

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -109,11 +109,11 @@ std::uint64_t EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender *
     SetSize_(3);
   } else if (Value <= 0xFFFFFFFF) {
     SetSize_(4);
-  } else if (Value <= EBML_PRETTYLONGINT(0xFFFFFFFFFF)) {
+  } else if (Value <= 0xFFFFFFFFFFLL) {
     SetSize_(5);
-  } else if (Value <= EBML_PRETTYLONGINT(0xFFFFFFFFFFFF)) {
+  } else if (Value <= 0xFFFFFFFFFFFFLL) {
     SetSize_(6);
-  } else if (Value <= EBML_PRETTYLONGINT(0xFFFFFFFFFFFFFF)) {
+  } else if (Value <= 0xFFFFFFFFFFFFFFLL) {
     SetSize_(7);
   } else {
     SetSize_(8);


### PR DESCRIPTION
EBML_PRETTYLONGINT should not exists as there are standard ways to do it in C++ now.

Also for uint64_t literals we should use UINT64_C found in cstdint, like uint64_t.