### PR TITLE
Add a simpler/faster Endian API for 16/32/64 Big-Endian buffers

### DIFF
--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -52,21 +52,19 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
   binary Buffer[8];
   input.readFully(Buffer, GetSize());
 
-  big_int64 b64;
-  b64.Eval(Buffer);
-
-  myDate = b64;
+  myDate = endian::from_big64(Buffer);
   SetValueIsSet();
   return GetSize();
 }
 
 filepos_t EbmlDate::RenderData(IOCallback & output, bool /* bForceRender */, bool  /* bWithDefault */)
 {
-  if (GetSize() != 0) {
-    assert(GetSize() == 8);
-    const auto b64 = big_int64(myDate);
+  assert(GetSize() == 8 || GetSize() == 0);
+  if (GetSize() == 8) {
+    binary b64[8];
+    endian::to_big64(myDate, b64);
 
-    output.writeFully(&b64.endian(),GetSize());
+    output.writeFully(b64,8);
   }
 
   return GetSize();

--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -33,6 +33,7 @@
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
 
+#include <algorithm>
 #include <limits>
 #include <sstream>
 #include <stdexcept>

--- a/src/MemReadIOCallback.cpp
+++ b/src/MemReadIOCallback.cpp
@@ -35,6 +35,7 @@
 */
 
 #include <cstring>
+#include <algorithm>
 
 #include "ebml/EbmlBinary.h"
 #include "ebml/MemReadIOCallback.h"

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -35,6 +35,7 @@
 */
 
 #include <cstring>
+#include <algorithm>
 
 #include "ebml/EbmlBinary.h"
 #include "ebml/MemReadIOCallback.h"


### PR DESCRIPTION
Ultimately we can remove the generic Endian<> class. When compiled with GCC and Clang the bytes reversal can be a simple instruction. It may be the case for MSVC as well.