### PR TITLE
Use the strict access API

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -89,11 +89,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
 
     bool operator==(const EbmlBinary & ElementToCompare) const;
 
-#if defined(EBML_STRICT_API)
   private:
-#else
-  protected:
-#endif
     binary *Data{nullptr}; // the binary data inside the element
 };
 

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -85,11 +85,7 @@ DECLARE_EBML_BINARY(EbmlCrc32)
 
     void ForceCrc32(std::uint32_t NewValue) { m_crc_final = NewValue; SetValueIsSet();}
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     void ResetCRC();
     void UpdateByte(binary b);
 

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -82,11 +82,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
       return false;
     }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
 
     std::int64_t myDate{0}; ///< internal format of the date

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -58,7 +58,7 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
     EbmlElement * Clone() const override { return &Create(); }
 
     static EbmlElement & Create() { return *(new EbmlDummy); }
-    static const EbmlId & ClassId();
+    static const EbmlId & ClassId() { return DummyRawId; };
     static const EbmlCallbacks ClassInfos;
 
   private:

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -48,15 +48,22 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
     bool IsDummy() const override {return true;}
     bool IsDefaultValue() const override {return true;}
 
-        operator const EbmlId &() const override {
-            return DummyId;
-        }
+    operator const EbmlId &() const override {
+        return DummyId;
+    }
 
-    private:
+    const EbmlSemanticContext &Context() const override;
+    const char *DebugName() const override { return "DummyElement"; }
+    EbmlElement & CreateElement() const override { return Create(); }
+    EbmlElement * Clone() const override { return &Create(); }
+
+    static EbmlElement & Create() { return *(new EbmlDummy); }
+    static const EbmlId & ClassId();
+    static const EbmlCallbacks ClassInfos;
+
+  private:
     const EbmlId DummyId;
     static const EbmlId DummyRawId;
-
-        EBML_CONCRETE_DUMMY_CLASS(EbmlDummy)
 };
 
 } // namespace libebml

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -48,8 +48,8 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
     bool IsDummy() const override {return true;}
     bool IsDefaultValue() const override {return true;}
 
-    operator const EbmlId &() const override {
-        return DummyId;
+    EbmlId const &GetClassId() const override {
+      return DummyId;
     }
 
     const EbmlSemanticContext &Context() const override;

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -52,11 +52,7 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
             return DummyId;
         }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     const EbmlId DummyId;
     static const EbmlId DummyRawId;
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -274,18 +274,19 @@ class EBML_DLL_API EbmlCallbacks {
 */
 class EBML_DLL_API EbmlSemantic {
   public:
-    constexpr EbmlSemantic(bool aMandatory, bool aUnique, const EbmlCallbacks & aGetCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), GetCallbacks(aGetCallbacks) {}
+    constexpr EbmlSemantic(bool aMandatory, bool aUnique, const EbmlCallbacks & aCallbacks)
+      :Mandatory(aMandatory), Unique(aUnique), Callbacks(aCallbacks) {}
 
         inline bool IsMandatory() const { return Mandatory; }
         inline bool IsUnique() const { return Unique; }
-        inline EbmlElement & Create() const { return EBML_INFO_CREATE(GetCallbacks); }
-        inline explicit operator const EbmlCallbacks &() const { return GetCallbacks; }
+        inline EbmlElement & Create() const { return EBML_INFO_CREATE(Callbacks); }
+        inline explicit operator const EbmlCallbacks &() const { return Callbacks; }
+        inline EbmlCallbacks const &GetCallbacks() const { return Callbacks; }
 
     private:
     bool Mandatory; ///< wether the element is mandatory in the context or not
     bool Unique;
-    const EbmlCallbacks & GetCallbacks;
+    const EbmlCallbacks & Callbacks;
 };
 
 using _GetSemanticContext = const class EbmlSemanticContext &(*)();

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -196,7 +196,6 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
   public: \
     x();
 
-#if defined(EBML_STRICT_API)
 #define EBML_CONCRETE_CLASS(Type) \
     public: \
         const EbmlSemanticContext &Context() const override {return ClassInfos.GetContext();} \
@@ -245,50 +244,6 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define EBML_CTX_IDX(c,i)      (c).GetSemantic(i)
 #define EBML_CTX_IDX_INFO(c,i) (const EbmlCallbacks &)((c).GetSemantic(i))
 #define EBML_CTX_IDX_ID(c,i)   ((const EbmlCallbacks &)((c).GetSemantic(i))).ClassId()
-#else
-#define EBML_CONCRETE_CLASS(Type) \
-    public: \
-    const EbmlCallbacks & Generic() const override {return ClassInfos;} \
-    operator const EbmlId &() const override {return ClassInfos.GlobalId;} \
-        EbmlElement & CreateElement() const override {return Create();} \
-        EbmlElement * Clone() const override { return new Type(*this); } \
-    static EbmlElement & Create() {return *(new (Type));} \
-    static const EbmlCallbacks ClassInfos; \
-
-#define EBML_CONCRETE_DUMMY_CLASS(Type) \
-    public: \
-    const EbmlCallbacks & Generic() const override {return ClassInfos;} \
-    virtual operator const EbmlId &(); \
-        EbmlElement & CreateElement() const override {return Create();} \
-        EbmlElement * Clone() const override { return new Type(*this); } \
-    static EbmlElement & Create() {return *(new (Type));} \
-    static const EbmlCallbacks ClassInfos; \
-
-
-#define EBML_INFO(ref)             ref::ClassInfos
-#define EBML_ID(ref)               ref::ClassInfos.GlobalId
-#define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
-#define EBML_CLASS_CONTEXT(ref)    ref::ClassInfos.Context
-#define EBML_CLASS_CALLBACK(ref)   ref::ClassInfos
-#define EBML_CONTEXT(e)            (e)->Generic().Context
-#define EBML_NAME(e)               (e)->Generic().DebugName
-
-#define EBML_INFO_ID(cb)      (cb).GlobalId
-#define EBML_INFO_NAME(cb)    (cb).DebugName
-#define EBML_INFO_CREATE(cb)  (cb).Create()
-#define EBML_INFO_CONTEXT(cb) (cb).Context
-
-#define EBML_SEM_UNIQUE(s)  (s).Unique
-#define EBML_SEM_CONTEXT(s) (s).GetCallbacks.Context
-#define EBML_SEM_CREATE(s)  (s).Create()
-
-#define EBML_CTX_SIZE(c)       (c).Size
-#define EBML_CTX_MASTER(c)     (c).MasterElt
-#define EBML_CTX_PARENT(c)     (c).UpTable
-#define EBML_CTX_IDX(c,i)      (c).MyTable[(i)]
-#define EBML_CTX_IDX_INFO(c,i) (c).MyTable[(i)].GetCallbacks
-#define EBML_CTX_IDX_ID(c,i)   (c).MyTable[(i)].GetCallbacks.GlobalId
-#endif
 
 #if !defined(INVALID_FILEPOS_T)
 #define INVALID_FILEPOS_T 0
@@ -318,9 +273,7 @@ class EBML_DLL_API EbmlCallbacks {
         inline const char * GetName() const { return DebugName; }
         inline EbmlElement & NewElement() const { return Create(); }
 
-#if defined(EBML_STRICT_API)
     private:
-#endif
     EbmlElement & (*Create)();
     const EbmlId & GlobalId;
     const char * DebugName;
@@ -341,9 +294,7 @@ class EBML_DLL_API EbmlSemantic {
         inline EbmlElement & Create() const { return EBML_INFO_CREATE(GetCallbacks); }
         inline explicit operator const EbmlCallbacks &() const { return GetCallbacks; }
 
-#if defined(EBML_STRICT_API)
     private:
-#endif
     bool Mandatory; ///< wether the element is mandatory in the context or not
     bool Unique;
     const EbmlCallbacks & GetCallbacks;
@@ -378,9 +329,7 @@ class EBML_DLL_API EbmlSemanticContext {
 
     const _GetSemanticContext GetGlobalContext; ///< global elements supported at this level
 
-#if defined(EBML_STRICT_API)
     private:
-#endif
         const EbmlSemantic *MyTable; ///< First element in the table
     std::size_t Size;          ///< number of elements in the table
     const EbmlSemanticContext *UpTable; ///< Parent element
@@ -419,13 +368,8 @@ class EBML_DLL_API EbmlElement {
     virtual EbmlElement * Clone() const = 0;
 
     virtual explicit operator const EbmlId &() const = 0;
-#if defined(EBML_STRICT_API)
         virtual const char *DebugName() const = 0;
         virtual const EbmlSemanticContext &Context() const = 0;
-#else
-    /// return the generic callback to monitor a derived class
-    virtual const EbmlCallbacks & Generic() const = 0;
-#endif
         virtual EbmlElement & CreateElement() const = 0;
 
     // by default only allow to set element as finite (override when needed)
@@ -521,9 +465,7 @@ class EBML_DLL_API EbmlElement {
         inline void SetSizeIsFinite(bool Set = true) {bSizeIsFinite = Set;}
         inline std::uint64_t GetSizePosition() const {return SizePosition;}
 
-#if defined(EBML_STRICT_API)
   private:
-#endif
     std::uint64_t Size;        ///< the size of the data to write
     std::uint64_t DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
     int SizeLength{0}; /// the minimum size on which the size will be written (0 = optimal)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -209,18 +209,6 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
     private: \
     static const EbmlCallbacks ClassInfos; \
 
-#define EBML_CONCRETE_DUMMY_CLASS(Type) \
-    public: \
-        const EbmlSemanticContext &Context() const override {return *static_cast<EbmlSemanticContext*>(nullptr);} \
-        const char *DebugName() const override {return "DummyElement";} \
-    operator const EbmlId &(); \
-        EbmlElement & CreateElement() const override {return Create();} \
-        EbmlElement * Clone() const override { return new Type(*this); } \
-    static EbmlElement & Create() {return *(new Type);} \
-        static const EbmlId & ClassId(); \
-    static const EbmlCallbacks ClassInfos; \
-
-
 #define EBML_INFO(ref)             ref::ClassInfo()
 #define EBML_ID(ref)               ref::ClassId()
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -199,22 +199,22 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #if defined(EBML_STRICT_API)
 #define EBML_CONCRETE_CLASS(Type) \
     public: \
-        virtual const EbmlSemanticContext &Context() const {return ClassInfos.GetContext();} \
-        virtual const char *DebugName() const {return ClassInfos.GetName();} \
+        const EbmlSemanticContext &Context() const override {return ClassInfos.GetContext();} \
+        const char *DebugName() const override {return ClassInfos.GetName();} \
     operator const EbmlId &() const override {return ClassInfos.ClassId();} \
         EbmlElement & CreateElement() const override {return Create();} \
         EbmlElement * Clone() const override { return new Type(*this); } \
     static EbmlElement & Create() {return *(new Type);} \
-        static const EbmlCallbacks & ClassInfo() {return ClassInfos;} \
+        static constexpr const EbmlCallbacks & ClassInfo() {return ClassInfos;} \
         static const EbmlId & ClassId() {return ClassInfos.ClassId();} \
     private: \
     static const EbmlCallbacks ClassInfos; \
 
 #define EBML_CONCRETE_DUMMY_CLASS(Type) \
     public: \
-        virtual const EbmlSemanticContext &Context() const {return *static_cast<EbmlSemanticContext*>(nullptr);} \
-        virtual const char *DebugName() const {return "DummyElement";} \
-    operator const EbmlId &() override; \
+        const EbmlSemanticContext &Context() const override {return *static_cast<EbmlSemanticContext*>(nullptr);} \
+        const char *DebugName() const override {return "DummyElement";} \
+    operator const EbmlId &(); \
         EbmlElement & CreateElement() const override {return Create();} \
         EbmlElement * Clone() const override { return new Type(*this); } \
     static EbmlElement & Create() {return *(new Type);} \

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -200,7 +200,7 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
     public: \
         const EbmlSemanticContext &Context() const override {return ClassInfos.GetContext();} \
         const char *DebugName() const override {return ClassInfos.GetName();} \
-    operator const EbmlId &() const override {return ClassInfos.ClassId();} \
+        EbmlId const &GetClassId() const override {return ClassInfos.ClassId();} \
         EbmlElement & CreateElement() const override {return Create();} \
         EbmlElement * Clone() const override { return new Type(*this); } \
     static EbmlElement & Create() {return *(new Type);} \
@@ -356,7 +356,8 @@ class EBML_DLL_API EbmlElement {
     */
     virtual EbmlElement * Clone() const = 0;
 
-    virtual explicit operator const EbmlId &() const = 0;
+    virtual EbmlId const &GetClassId() const = 0;
+    virtual explicit operator const EbmlId &() const { return GetClassId(); }
         virtual const char *DebugName() const = 0;
         virtual const EbmlSemanticContext &Context() const = 0;
         virtual EbmlElement & CreateElement() const = 0;

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -212,11 +212,7 @@ template<class TYPE, endianess ENDIAN> class Endian
       inline std::size_t size() const   { return sizeof(TYPE); }
       inline bool operator!=(const binary *buffer) const {return *(reinterpret_cast<TYPE*>(buffer)) == platform_value;}
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
       TYPE platform_value;
       TYPE endian_value;
 

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -93,11 +93,7 @@ class EBML_DLL_API EbmlFloat : public EbmlElement {
       return (DefaultISset() && Value == DefaultValue);
     }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     double Value; /// The actual value of the element
     double DefaultValue;
 };

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -41,13 +41,8 @@
 namespace libebml {
 
 
-#if defined(EBML_STRICT_API)
 #define EBML_ID_VALUE(id)  (id).GetValue()
 #define EBML_ID_LENGTH(id) (id).GetLength()
-#else
-#define EBML_ID_VALUE(id)  (id).Value
-#define EBML_ID_LENGTH(id) (id).Length
-#endif
 
 /*!
   \class EbmlId
@@ -86,9 +81,7 @@ class EBML_DLL_API EbmlId {
         inline std::size_t GetLength() const { return Length; }
         inline std::uint32_t GetValue() const { return Value; }
 
-#if defined(EBML_STRICT_API)
     private:
-#endif
     std::uint32_t Value;
     std::size_t Length;
 };

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -181,7 +181,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     private:
     std::vector<EbmlElement *> ElementList;
 
-    const EbmlSemanticContext & Context;
+    const EbmlSemanticContext & MasterContext;
 
     bool      bChecksumUsed;
     EbmlCrc32 Checksum;

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -178,11 +178,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     */
     std::vector<std::string> FindAllMissingElements() const;
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     std::vector<EbmlElement *> ElementList;
 
     const EbmlSemanticContext & Context;

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -87,11 +87,7 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
       return (DefaultISset() && Value == DefaultValue);
     }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     std::int64_t Value; /// The actual value of the element
     std::int64_t DefaultValue;
 };

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -61,11 +61,7 @@ class EBML_DLL_API EbmlStream {
     inline IOCallback & I_O() {return Stream;}
         operator IOCallback &() {return Stream;}
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     IOCallback & Stream;
 };
 

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -72,11 +72,7 @@ class EBML_DLL_API EbmlString : public EbmlElement {
       return (DefaultISset() && Value == DefaultValue);
     }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     std::string Value;  /// The actual value of the element
     std::string DefaultValue;
 };

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -85,11 +85,7 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
       return (DefaultISset() && Value == DefaultValue);
     }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     std::uint64_t Value; /// The actual value of the element
     std::uint64_t DefaultValue;
 };

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -78,11 +78,7 @@ public:
   const std::string & GetUTF8() const {return UTF8string;}
   void SetUTF8(const std::string &);
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
   std::size_t _Length{0}; ///< length of the UCS string excluding the \0
   wchar_t* _Data{nullptr}; ///< internal UCS representation
   std::string UTF8string;
@@ -124,11 +120,7 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElement {
       return (DefaultISset() && Value == DefaultValue);
     }
 
-#if defined(EBML_STRICT_API)
     private:
-#else
-    protected:
-#endif
     UTFstring Value; /// The actual value of the element
     UTFstring DefaultValue;
 };

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -42,9 +42,9 @@ DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, 1, "DummyElement")
 
 const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
 
-EbmlDummy::operator const EbmlId &()
+const EbmlSemanticContext &EbmlDummy::Context() const
 {
-  return DummyId;
+  return Context_EbmlDummy;
 }
 
 } // namespace libebml


### PR DESCRIPTION
So far the code was built without the define. But since we can change the API for 2.0 we should switch to a stricter API that makes things less public.

This requires libmatroska to merge https://github.com/Matroska-Org/libmatroska/pull/95

We might be able to add some `constexpr` here and there despite using methods.