### PR TITLE
Properly update dataBufferMemorySize in MemIOCallback after realloc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 * Bumped the library's soname to 6 due to ABI breaking changes that
   already happened in 1.4.3.
 * Remove libebml_t.h.
+* Fix dataBufferMemorySize updating logic in `MemIOCallback::write()`.
+  It was not updated properly, leading to incorrect behavior when
+  write cursor moved back to, for example, rewrite the head of a file.
+  
 
 # Version 1.4.3 2022-09-30
 

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -98,6 +98,7 @@ std::size_t MemIOCallback::write(const void *Buffer, std::size_t Size)
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
     dataBuffer = static_cast<binary *>(realloc(static_cast<void *>(dataBuffer), dataBufferPos + Size));
+    dataBufferMemorySize = dataBufferPos + Size;
   }
   memcpy(dataBuffer+dataBufferPos, Buffer, Size);
   dataBufferPos += Size;
@@ -112,6 +113,7 @@ std::uint32_t MemIOCallback::write(IOCallback & IOToRead, std::size_t Size)
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
     dataBuffer = static_cast<binary *>(realloc(static_cast<void *>(dataBuffer), dataBufferPos + Size));
+    dataBufferMemorySize = dataBufferPos + Size;
   }
   IOToRead.readFully(&dataBuffer[dataBufferPos], Size);
   dataBufferTotalSize = Size;


### PR DESCRIPTION
dataBufferMemorySize was not being updated properly after realloc in MemIOCallback::write(). When writing the whole MKV file with frames then coming back to update the head of the file, this non-updated dataBufferMemorySize caused realloc in a way reducing the size of the file. This behavior causes loss of the frame data.