### PR TITLE
[1.x] Fix MemIOCallback buffer overflows

### DIFF
--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -68,7 +68,8 @@ uint32 MemIOCallback::read(void *Buffer, size_t Size)
   if (Buffer == nullptr || Size < 1)
     return 0;
   //If the size is larger than than the amount left in the buffer
-  if (Size + dataBufferPos > dataBufferTotalSize) {
+  if (Size + dataBufferPos < Size || // overflow, reading too much
+      Size + dataBufferPos > dataBufferTotalSize) {
     //We will only return the remaining data
     memcpy(Buffer, dataBuffer + dataBufferPos, dataBufferTotalSize - dataBufferPos);
     uint64 oldDataPos = dataBufferPos;

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -96,6 +96,8 @@ void MemIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
 
 size_t MemIOCallback::write(const void *Buffer, size_t Size)
 {
+  if (dataBufferPos + Size < Size) // overflow, we can't hold that much
+    return 0;
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
     dataBuffer = static_cast<binary *>(realloc(static_cast<void *>(dataBuffer), dataBufferPos + Size));
@@ -110,6 +112,8 @@ size_t MemIOCallback::write(const void *Buffer, size_t Size)
 
 uint32 MemIOCallback::write(IOCallback & IOToRead, size_t Size)
 {
+  if (dataBufferPos + Size < Size) // overflow, we can't hold that much
+    return 0;
   if (dataBufferMemorySize < dataBufferPos + Size) {
     //We need more memory!
     dataBuffer = static_cast<binary *>(realloc(static_cast<void *>(dataBuffer), dataBufferPos + Size));


### PR DESCRIPTION
Same as #148 for the 1.x branch.