### PR TITLE
[RFC] Store the default value in a union inside EbmlSemantic

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -227,6 +227,8 @@ class EBML_DLL_API EbmlCallbacks {
 */
 class EBML_DLL_API EbmlSemantic {
   public:
+    struct DefaultValues;
+
     constexpr EbmlSemantic(bool aMandatory, bool aUnique, const EbmlCallbacks & aCallbacks)
       :Mandatory(aMandatory), Unique(aUnique), defaultValue(), Callbacks(aCallbacks) {}
 
@@ -247,20 +249,21 @@ class EBML_DLL_API EbmlSemantic {
 
         inline bool IsMandatory() const { return Mandatory; }
         inline bool IsUnique() const { return Unique; }
-        inline bool HasDefault() const { return defaultValue.HasDefault(); }
+        inline const DefaultValues & DefaultValue() const { return defaultValue; }
         inline EbmlElement & Create() const { return EBML_INFO_CREATE(Callbacks); }
         inline explicit operator const EbmlCallbacks &() const { return Callbacks; }
         inline EbmlCallbacks const &GetCallbacks() const { return Callbacks; }
 
-     struct DefaultValues {
-      enum DefaultType {
-        NO_DEFAULT,
-        UINTEGER,
-        SINTEGER,
-        DOUBLE,
-        STRING,
-        UNISTRING,
-      } type;
+    enum DefaultType {
+      NO_DEFAULT,
+      UINTEGER,
+      SINTEGER,
+      DOUBLE,
+      STRING,
+      UNISTRING,
+    };
+   struct DefaultValues {
+      DefaultType type;
       union {
         std::uint64_t  u64;
         std::int64_t   i64;

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -128,6 +128,7 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define DEFINE_START_SEMANTIC(x)     static const EbmlSemantic ContextList_##x[] = {
 #define DEFINE_END_SEMANTIC(x)       };
 #define DEFINE_SEMANTIC_ITEM(m,u,c)  EbmlSemantic(m, u, EBML_INFO(c)),
+#define DEFINE_SEMANTIC_ITEM_UINT(m,u,d,c)  EbmlSemantic(m, u, true, EBML_INFO(c)),
 
 #define DECLARE_EBML_MASTER(x)  class EBML_DLL_API x : public EbmlMaster { \
   public: \
@@ -223,10 +224,14 @@ class EBML_DLL_API EbmlCallbacks {
 class EBML_DLL_API EbmlSemantic {
   public:
     constexpr EbmlSemantic(bool aMandatory, bool aUnique, const EbmlCallbacks & aCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), Callbacks(aCallbacks) {}
+      :Mandatory(aMandatory), Unique(aUnique), hasDefault(false), Callbacks(aCallbacks) {}
+
+    constexpr EbmlSemantic(bool aMandatory, bool aUnique, bool HasDefault, const EbmlCallbacks & aCallbacks)
+      :Mandatory(aMandatory), Unique(aUnique), hasDefault(HasDefault), Callbacks(aCallbacks) {}
 
         inline bool IsMandatory() const { return Mandatory; }
         inline bool IsUnique() const { return Unique; }
+        inline bool HasDefault() const { return hasDefault; }
         inline EbmlElement & Create() const { return EBML_INFO_CREATE(Callbacks); }
         inline explicit operator const EbmlCallbacks &() const { return Callbacks; }
         inline EbmlCallbacks const &GetCallbacks() const { return Callbacks; }
@@ -234,6 +239,7 @@ class EBML_DLL_API EbmlSemantic {
     private:
     const bool Mandatory; ///< whether the element is mandatory in the context or not
     const bool Unique;
+    const bool hasDefault;
     const EbmlCallbacks & Callbacks;
 };
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -232,20 +232,8 @@ class EBML_DLL_API EbmlSemantic {
     constexpr EbmlSemantic(bool aMandatory, bool aUnique, const EbmlCallbacks & aCallbacks)
       :Mandatory(aMandatory), Unique(aUnique), defaultValue(), Callbacks(aCallbacks) {}
 
-    constexpr EbmlSemantic(bool aMandatory, bool aUnique, std::uint64_t def, const EbmlCallbacks & aCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), defaultValue(def), Callbacks(aCallbacks) {}
-
-    constexpr EbmlSemantic(bool aMandatory, bool aUnique, std::int64_t def, const EbmlCallbacks & aCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), defaultValue(def), Callbacks(aCallbacks) {}
-
-    constexpr EbmlSemantic(bool aMandatory, bool aUnique, double def, const EbmlCallbacks & aCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), defaultValue(def), Callbacks(aCallbacks) {}
-
-    constexpr EbmlSemantic(bool aMandatory, bool aUnique, const char *def, const EbmlCallbacks & aCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), defaultValue(def), Callbacks(aCallbacks) {}
-
-    constexpr EbmlSemantic(bool aMandatory, bool aUnique, const wchar_t *def, const EbmlCallbacks & aCallbacks)
-      :Mandatory(aMandatory), Unique(aUnique), defaultValue(def), Callbacks(aCallbacks) {}
+    constexpr EbmlSemantic(bool aMandatory, bool aUnique, const DefaultValues &def, const EbmlCallbacks & aGetCallbacks)
+      :Mandatory(aMandatory), Unique(aUnique), defaultValue(def), Callbacks(aGetCallbacks) {}
 
         inline bool IsMandatory() const { return Mandatory; }
         inline bool IsUnique() const { return Unique; }
@@ -273,6 +261,7 @@ class EBML_DLL_API EbmlSemantic {
       };
 
       constexpr DefaultValues(void) : u64(0), type(DefaultType::NO_DEFAULT) {}
+      constexpr DefaultValues(const DefaultValues &) = default;
       constexpr DefaultValues(std::uint64_t u) : u64(u), type(DefaultType::UINTEGER) {}
       constexpr DefaultValues(std::int64_t u) : i64(u), type(DefaultType::UINTEGER) {}
       constexpr DefaultValues(double d) : f(d), type(DefaultType::DOUBLE) {}

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -130,6 +130,7 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define DEFINE_SEMANTIC_ITEM(m,u,c)  EbmlSemantic(m, u, EBML_INFO(c)),
 #define DEFINE_SEMANTIC_ITEM_UINT(m,u,d,c)      EbmlSemantic(m, u, static_cast<std::uint64_t>(d), EBML_INFO(c)),
 #define DEFINE_SEMANTIC_ITEM_SINT(m,u,d,c)      EbmlSemantic(m, u, static_cast<std::int64_t>(d),  EBML_INFO(c)),
+#define DEFINE_SEMANTIC_ITEM_DATE(m,u,d,c)      EbmlSemantic(m, u, static_cast<std::int64_t>(d,true), EBML_INFO(c)),
 #define DEFINE_SEMANTIC_ITEM_FLOAT(m,u,d,c)     EbmlSemantic(m, u, static_cast<double>(d),        EBML_INFO(c)),
 #define DEFINE_SEMANTIC_ITEM_STRING(m,u,d,c)    EbmlSemantic(m, u, static_cast<const char*>(d),    EBML_INFO(c)),
 #define DEFINE_SEMANTIC_ITEM_UTF8(m,u,d,c)      EbmlSemantic(m, u, static_cast<const wchar_t*>(d), EBML_INFO(c)),
@@ -246,6 +247,7 @@ class EBML_DLL_API EbmlSemantic {
       NO_DEFAULT,
       UINTEGER,
       SINTEGER,
+      DATE,
       DOUBLE,
       STRING,
       UNISTRING,
@@ -263,7 +265,7 @@ class EBML_DLL_API EbmlSemantic {
       constexpr DefaultValues(void) : u64(0), type(DefaultType::NO_DEFAULT) {}
       constexpr DefaultValues(const DefaultValues &) = default;
       constexpr DefaultValues(std::uint64_t u) : u64(u), type(DefaultType::UINTEGER) {}
-      constexpr DefaultValues(std::int64_t u) : i64(u), type(DefaultType::UINTEGER) {}
+      constexpr DefaultValues(std::int64_t u, bool date = false) : i64(u), type(date ? DefaultType::UINTEGER : DefaultType::DATE) {}
       constexpr DefaultValues(double d) : f(d), type(DefaultType::DOUBLE) {}
       constexpr DefaultValues(const char *d) : s(d), type(DefaultType::STRING) {}
       constexpr DefaultValues(const wchar_t *d) : ws(d), type(DefaultType::UNISTRING) {}

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -12,13 +12,13 @@
 namespace libebml {
 
 DEFINE_START_SEMANTIC(EbmlHead)
-DEFINE_SEMANTIC_ITEM(true, true, EVersion)        ///< EBMLVersion
-DEFINE_SEMANTIC_ITEM(true, true, EReadVersion)    ///< EBMLReadVersion
-DEFINE_SEMANTIC_ITEM(true, true, EMaxIdLength)    ///< EBMLMaxIdLength
-DEFINE_SEMANTIC_ITEM(true, true, EMaxSizeLength)  ///< EBMLMaxSizeLength
+DEFINE_SEMANTIC_ITEM_UINT(true, true, 1, EVersion)        ///< EBMLVersion
+DEFINE_SEMANTIC_ITEM_UINT(true, true, 1, EReadVersion)    ///< EBMLReadVersion
+DEFINE_SEMANTIC_ITEM_UINT(true, true, 4, EMaxIdLength)    ///< EBMLMaxIdLength
+DEFINE_SEMANTIC_ITEM_UINT(true, true, 8, EMaxSizeLength)  ///< EBMLMaxSizeLength
 DEFINE_SEMANTIC_ITEM(true, true, EDocType)        ///< DocType
-DEFINE_SEMANTIC_ITEM(true, true, EDocTypeVersion) ///< DocTypeVersion
-DEFINE_SEMANTIC_ITEM(true, true, EDocTypeReadVersion) ///< DocTypeReadVersion
+DEFINE_SEMANTIC_ITEM_UINT(true, true, 1, EDocTypeVersion) ///< DocTypeVersion
+DEFINE_SEMANTIC_ITEM_UINT(true, true, 1, EDocTypeReadVersion) ///< DocTypeReadVersion
 DEFINE_END_SEMANTIC(EbmlHead)
 
 DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, 4, "EBMLHead\0ratamapaga")


### PR DESCRIPTION
A template might be cleaner, more type-safe. I gave it a try but it seemed very instrusive (all classes need to be touched).

This provides a basic system to set the default value in the semantic. If approve we can change how we set default values in libmatroska, using the new macros. And then we can switch the access to the default value to this storage in EbmlSemantic.