### PR TITLE
Make more variables const so we have more constexpr constructors

### DIFF
--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -51,14 +51,14 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
       \brief set the date with a UNIX/C/EPOCH form
       \param NewDate UNIX/C date in UTC (no timezone)
     */
-    void SetEpochDate(std::int64_t NewDate) {myDate = (NewDate - UnixEpochDelay) * 1000000000; SetValueIsSet();}
+    void SetEpochDate(std::int64_t NewDate) {myDate = (NewDate - UnixEpochDelay) * 1'000'000'000; SetValueIsSet();}
     EbmlDate &SetValue(std::int64_t NewValue) {SetEpochDate(NewValue); return *this;}
 
     /*!
       \brief get the date with a UNIX/C/EPOCH form
       \note the date is in UTC (no timezone)
     */
-    std::int64_t GetEpochDate() const {return static_cast<std::int64_t>(myDate/1000000000 + UnixEpochDelay);}
+    std::int64_t GetEpochDate() const {return static_cast<std::int64_t>(myDate/1'000'000'000 + UnixEpochDelay);}
     std::int64_t GetValue() const {return GetEpochDate();}
 
     bool ValidateSize() const override {return IsFiniteSize() && ((GetSize() == 8) || (GetSize() == 0));}
@@ -87,7 +87,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 
     std::int64_t myDate{0}; ///< internal format of the date
 
-    static constexpr std::uint64_t UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
+    static constexpr std::uint64_t UnixEpochDelay = 978'307'200; // 2001/01/01 00:00:00 UTC
 };
 
 } // namespace libebml

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -87,7 +87,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 
     std::int64_t myDate{0}; ///< internal format of the date
 
-    static const std::uint64_t UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
+    static constexpr std::uint64_t UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
 };
 
 } // namespace libebml

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -256,7 +256,14 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 */
 class EBML_DLL_API EbmlCallbacks {
   public:
-    EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, const char * aDebugName, const EbmlSemanticContext & aContext);
+    constexpr EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, const char * aDebugName, const EbmlSemanticContext & aContext)
+      :Create(Creator)
+      ,GlobalId(aGlobalId)
+      ,DebugName(aDebugName)
+      ,Context(aContext)
+    {
+      assert(Creator!=nullptr);
+    }
 
         inline const EbmlId & ClassId() const { return GlobalId; }
         inline const EbmlSemanticContext & GetContext() const { return Context; }

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -102,62 +102,62 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,idl,parent,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlMaster(Context_##x) {}
 
 #define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_xxx_CLASS(x,id,idl,parent,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() {}
 
 #define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,global,defval) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlUInteger(defval) {}
 
 #define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,global,defval) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlSInteger(defval) {}
 
 #define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,global,defval) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlString(defval) {}
 
 #define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,global,defval) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlFloat(defval) {}
 
 #define DEFINE_xxx_CLASS_GLOBAL(x,id,idl,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,global) \
-    const EbmlId Id_##x    (id, idl); \
+    constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
     const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -306,7 +306,7 @@ using _GetSemanticContext = const class EbmlSemanticContext &(*)();
 */
 class EBML_DLL_API EbmlSemanticContext {
   public:
-    EbmlSemanticContext(std::size_t aSize,
+    constexpr EbmlSemanticContext(std::size_t aSize,
       const EbmlSemantic *aMyTable,
       const EbmlSemanticContext *aUpTable,
       const _GetSemanticContext aGetGlobalContext,

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -284,8 +284,8 @@ class EBML_DLL_API EbmlSemantic {
         inline EbmlCallbacks const &GetCallbacks() const { return Callbacks; }
 
     private:
-    bool Mandatory; ///< wether the element is mandatory in the context or not
-    bool Unique;
+    const bool Mandatory; ///< whether the element is mandatory in the context or not
+    const bool Unique;
     const EbmlCallbacks & Callbacks;
 };
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -37,6 +37,8 @@
 #include "EbmlId.h"
 #include "IOCallback.h"
 
+#include <cassert>
+
 namespace libebml {
 
 template <typename T, std::size_t N>

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -104,62 +104,62 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define DEFINE_xxx_MASTER(x,id,idl,parent,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlMaster(Context_##x) {}
 
 #define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_xxx_CLASS(x,id,idl,parent,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() {}
 
 #define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x);
 
 #define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlUInteger(defval) {}
 
 #define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,global,defval) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlSInteger(defval) {}
 
 #define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,global,defval) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlString(defval) {}
 
 #define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,global,defval) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x)); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
     x::x() :EbmlFloat(defval) {}
 
 #define DEFINE_xxx_CLASS_GLOBAL(x,id,idl,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_EbmlGlobal); \
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \
     const EbmlSemanticContext Context_##x = EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
-    const EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    constexpr EbmlCallbacks x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,GetEbmlGlobal_Context)
 #define DEFINE_EBML_MASTER(x,id,idl,parent,name)           DEFINE_xxx_MASTER(x,id,idl,parent,name,GetEbmlGlobal_Context)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -320,7 +320,7 @@ class EBML_DLL_API EbmlSemanticContext {
 
     private:
         const EbmlSemantic *MyTable; ///< First element in the table
-    std::size_t Size;          ///< number of elements in the table
+    const std::size_t Size;          ///< number of elements in the table
     const EbmlSemanticContext *UpTable; ///< Parent element
     /// \todo replace with the global context directly
     const EbmlCallbacks *MasterElt;

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -262,7 +262,7 @@ class EBML_DLL_API EbmlCallbacks {
         inline EbmlElement & NewElement() const { return Create(); }
 
     private:
-    EbmlElement & (*Create)();
+    EbmlElement & (* const Create)();
     const EbmlId & GlobalId;
     const char * DebugName;
     const EbmlSemanticContext & Context;

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -50,13 +50,9 @@ namespace libebml {
 class EBML_DLL_API EbmlId {
   public:
     EbmlId(const binary aValue[4], const unsigned int aLength)
-      :Value(0)
+      :Value(FromBuffer(aValue, aLength))
       ,Length(aLength)
     {
-      for (unsigned int i=0; i<aLength; i++) {
-        Value <<= 8;
-        Value += aValue[i];
-      }
     }
 
     EbmlId(const std::uint32_t aValue, const unsigned int aLength)
@@ -82,8 +78,18 @@ class EBML_DLL_API EbmlId {
         inline std::uint32_t GetValue() const { return Value; }
 
     private:
-    std::uint32_t Value;
-    std::size_t Length;
+    const std::uint32_t Value;
+    const std::size_t Length;
+
+    static std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)
+    {
+      std::uint32_t Value = 0;
+      for (unsigned int i=0; i<aLength; i++) {
+        Value <<= 8;
+        Value += aValue[i];
+      }
+      return Value;
+    }
 };
 
 } // namespace libebml

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -49,13 +49,13 @@ namespace libebml {
 */
 class EBML_DLL_API EbmlId {
   public:
-    EbmlId(const binary aValue[4], const unsigned int aLength)
+    constexpr EbmlId(const binary aValue[4], const unsigned int aLength)
       :Value(FromBuffer(aValue, aLength))
       ,Length(aLength)
     {
     }
 
-    EbmlId(const std::uint32_t aValue, const unsigned int aLength)
+    constexpr EbmlId(const std::uint32_t aValue, const unsigned int aLength)
       :Value(aValue), Length(aLength) {}
 
     inline bool operator==(const EbmlId & TestId) const
@@ -81,7 +81,7 @@ class EBML_DLL_API EbmlId {
     const std::uint32_t Value;
     const std::size_t Length;
 
-    static std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)
+    static constexpr std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)
     {
       std::uint32_t Value = 0;
       for (unsigned int i=0; i<aLength; i++) {

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -211,15 +211,6 @@ std::int64_t ReadCodedSizeSignedValue(const binary * InBuffer, std::uint32_t & B
 }
 
 
-EbmlCallbacks::EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, const char * aDebugName, const EbmlSemanticContext & aContext)
-  :Create(Creator)
-  ,GlobalId(aGlobalId)
-  ,DebugName(aDebugName)
-  ,Context(aContext)
-{
-  assert(Create!=nullptr);
-}
-
 const EbmlSemantic & EbmlSemanticContext::GetSemantic(std::size_t i) const
 {
   assert(i<Size);

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -217,7 +217,7 @@ EbmlCallbacks::EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalI
   ,DebugName(aDebugName)
   ,Context(aContext)
 {
-  assert((Create!=nullptr) || !strcmp(aDebugName, "DummyElement"));
+  assert(Create!=nullptr);
 }
 
 const EbmlSemantic & EbmlSemanticContext::GetSemantic(std::size_t i) const


### PR DESCRIPTION
The API is designed to set the values on creation and not touch them again.

Also change some integer constants so they are more readable.

The `EbmlSemanticContext` cannot be a `constexpr` (for now?) because it's exported as `extern const`.