### PR TITLE
Remove Legacy macros/defines

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -190,15 +190,12 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define EBML_INFO(ref)             ref::ClassInfo()
 #define EBML_ID(ref)               ref::ClassId()
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
-#define EBML_CLASS_CONTEXT(ref)    ref::ClassInfo().GetContext()
-#define EBML_CLASS_CALLBACK(ref)   ref::ClassInfo()
 #define EBML_CONTEXT(e) (e)->Context()
 #define EBML_NAME(e)    (e)->DebugName()
 
 #define EBML_INFO_ID(cb)      (cb).ClassId()
 #define EBML_INFO_NAME(cb)    (cb).GetName()
 #define EBML_INFO_CREATE(cb)  (cb).NewElement()
-#define EBML_INFO_CONTEXT(cb) (cb).GetContext()
 
 #define EBML_SEM_CONTEXT(s) ((const EbmlCallbacks &)(s)).GetContext()
 #define EBML_SEM_CREATE(s)  (s).Create()

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -200,7 +200,6 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define EBML_INFO_CREATE(cb)  (cb).NewElement()
 #define EBML_INFO_CONTEXT(cb) (cb).GetContext()
 
-#define EBML_SEM_UNIQUE(s)  (s).IsUnique()
 #define EBML_SEM_CONTEXT(s) ((const EbmlCallbacks &)(s)).GetContext()
 #define EBML_SEM_CREATE(s)  (s).Create()
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -215,17 +215,6 @@ extern const EbmlSemanticContext Context_EbmlGlobal;
 #define INVALID_FILEPOS_T 0
 #endif
 
-#define EBML_DEF_CONS
-#define EBML_DEF_SEP
-#define EBML_DEF_PARAM
-#define EBML_DEF_BINARY_INIT
-#define EBML_DEF_BINARY_CTX(x)
-#define EBML_DEF_SINTEGER(x)
-#define EBML_DEF_BINARY(x)
-#define EBML_EXTRA_PARAM
-#define EBML_EXTRA_CALL
-#define EBML_EXTRA_DEF
-
 // functions for generic handling of data (should be static to all classes)
 /*!
   \todo Handle default value


### PR DESCRIPTION
They are not used anywhere. We don't need to maintain unused code.