### PR TITLE
don't keep null clones

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -61,7 +61,11 @@ EbmlMaster::EbmlMaster(const EbmlMaster & ElementToClone)
   ElementList.reserve(ElementToClone.ListSize());
   // add a clone of the list
   for (const auto& e : ElementToClone.ElementList)
-    ElementList.push_back(e->Clone());
+  {
+    auto *clone = e->Clone();
+    if (clone != nullptr)
+      ElementList.push_back(clone);
+  }
 }
 
 EbmlMaster::~EbmlMaster()


### PR DESCRIPTION
This will crash in the destructor and many other places.

It's unlikely to happen by better safe than sorry.

This should probably be backported to 1,x