### PR TITLE
Handle Push element error

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -121,8 +121,12 @@ filepos_t EbmlMaster::RenderData(IOCallback & output, bool bForceRender, bool bW
 */
 bool EbmlMaster::PushElement(EbmlElement & element)
 {
-  ElementList.push_back(&element);
-  return true;
+  try {
+    ElementList.push_back(&element);
+    return true;
+  } catch(...) {
+  }
+  return false;
 }
 
 std::uint64_t EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -190,7 +190,20 @@ bool EbmlMaster::ProcessMandatory()
   for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory() && EBML_CTX_IDX(MasterContext,EltIdx).IsUnique()) {
 //      assert(EBML_CTX_IDX(MasterContext,EltIdx).Create != NULL);
-            PushElement(EBML_SEM_CREATE(EBML_CTX_IDX(MasterContext,EltIdx)));
+      if (PushElement(EBML_SEM_CREATE(EBML_CTX_IDX(MasterContext,EltIdx))))
+        continue;
+
+      while (EltIdx-- != 0)
+      {
+        if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory() && EBML_CTX_IDX(MasterContext,EltIdx).IsUnique())
+        {
+          // element that have been pushed should be removed
+          auto *todelete = ElementList.back();
+          ElementList.pop_back();
+          delete todelete;
+        }
+      }
+      return false;
     }
   }
   return true;


### PR DESCRIPTION
Not sure if we should make the EbmlMaster constructor throw in this case. There might be some code assuming Mandatory elements are available no matter what. This is also needed in the copy constructor of #162. But it would break the API/ABI so not for 1.x.

This only happens when pushing to a vector fails, so extremely limited memory constraints.