### PR TITLE
[1.x] don't keep null clones

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -64,8 +64,13 @@ EbmlMaster::EbmlMaster(const EbmlMaster & ElementToClone)
   auto myItr = ElementList.begin();
   while (Itr != ElementToClone.ElementList.end())
   {
-    *myItr = (*Itr)->Clone();
-    ++Itr; ++myItr;
+    auto *clone = (*Itr)->Clone();
+    if (clone != nullptr)
+    {
+     *myItr = clone;
+     ++myItr;
+    }
+    ++Itr;
   }
 
 }


### PR DESCRIPTION
This will crash in the destructor and many other places.

It's unlikely to happen but better safe than sorry.

(cherry picked from commit ca27cb05f1955a4b8db35edd5935eec613684aae) (edited)