### PR TITLE
remove EbmlElement locking

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -296,7 +296,7 @@ class EBML_DLL_API EbmlSemanticContext {
 class EBML_DLL_API EbmlElement {
   public:
     explicit EbmlElement(std::uint64_t aDefaultSize, bool bValueSet = false);
-    virtual ~EbmlElement();
+    virtual ~EbmlElement() = default;
     EbmlElement& operator=(const EbmlElement&) = delete;
 
     /// Set the minimum length that will be used to write the element size (-1 = optimal)
@@ -343,9 +343,6 @@ class EBML_DLL_API EbmlElement {
 
     virtual filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) = 0;
     virtual void Read(EbmlStream & inDataStream, const EbmlSemanticContext & Context, int & UpperEltFound, EbmlElement * & FoundElt, bool AllowDummyElt = false, ScopeMode ReadFully = SCOPE_ALL_DATA);
-
-    bool IsLocked() const {return bLocked;}
-    void Lock(bool bLock = true) { bLocked = bLock;}
 
     /*!
       \brief default comparison for elements that can't be compared
@@ -427,7 +424,6 @@ class EBML_DLL_API EbmlElement {
     std::uint64_t SizePosition{0};
     bool bValueIsSet;
     bool DefaultIsSet{false};
-    bool bLocked{false};
 };
 
 } // namespace libebml

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -174,11 +174,6 @@ EbmlElement::EbmlElement(std::uint64_t aDefaultSize, bool bValueSet)
   Size = DefaultSize;
 }
 
-EbmlElement::~EbmlElement()
-{
-  assert(!bLocked);
-}
-
 /*!
   \todo this method is deprecated and should be called FindThisID
   \todo replace the new RawElement with the appropriate class (when known)

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -70,12 +70,8 @@ EbmlMaster::EbmlMaster(const EbmlMaster & ElementToClone)
 
 EbmlMaster::~EbmlMaster()
 {
-  assert(!IsLocked()); // you're trying to delete a locked element !!!
-
   for (auto Element : ElementList) {
-    if (!Element->IsLocked())  {
-      delete Element;
-    }
+    delete Element;
   }
 }
 
@@ -375,9 +371,7 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
   EbmlElement * ElementLevelA;
   // remove all existing elements, including the mandatory ones...
   for (auto Element : ElementList) {
-    if (!Element->IsLocked()) {
-        delete Element;
-    }
+    delete Element;
   }
   ElementList.clear();
   std::uint64_t MaxSizeToRead;


### PR DESCRIPTION
This was designed to be able to keep a pointer alive after its parent master element is destroyed. But it's not used anywhere and a C++ refcounting should be used for that.