### PR TITLE
Use a SPDX header for the LGPL 2.1 license

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlConfig.h
+++ b/ebml/EbmlConfig.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlHead.h
+++ b/ebml/EbmlHead.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlSubHead.h
+++ b/ebml/EbmlSubHead.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlVersion.h
+++ b/ebml/EbmlVersion.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/EbmlVoid.h
+++ b/ebml/EbmlVoid.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Ingo Ralf Blum.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Ingo Ralf Blum.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/MemIOCallback.h
+++ b/ebml/MemIOCallback.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2003-2004 Jory Stone.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2003-2004 Jory Stone.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/MemReadIOCallback.h
+++ b/ebml/MemReadIOCallback.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2014 Moritz Bunkus.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.matroska.org/license/lgpl/ for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2014 Moritz Bunkus.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2014 Moritz Bunkus.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.matroska.org/license/lgpl/ for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2014 Moritz Bunkus.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/ebml/StdIOCallback.h
+++ b/ebml/StdIOCallback.h
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Ingo Ralf Blum.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Ingo Ralf Blum.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file
@@ -43,7 +16,7 @@
 namespace libebml {
 
 EbmlBinary::EbmlBinary()
-  :EbmlElement(0, false) 
+  :EbmlElement(0, false)
 {}
 
 EbmlBinary::EbmlBinary(const EbmlBinary & ElementToClone)

--- a/src/EbmlContexts.cpp
+++ b/src/EbmlContexts.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlStream.cpp
+++ b/src/EbmlStream.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlSubHead.cpp
+++ b/src/EbmlSubHead.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlVersion.cpp
+++ b/src/EbmlVersion.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Ingo Ralf Blum.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Ingo Ralf Blum.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2003 Jory Stone.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2003 Jory Stone.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/MemReadIOCallback.cpp
+++ b/src/MemReadIOCallback.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2014 Moritz Bunkus.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.matroska.org/license/lgpl/ for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2014 Moritz Bunkus.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -1,32 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2014 Moritz Bunkus.  All rights reserved.
-**
-** This file is part of libebml.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.matroska.org/license/lgpl/ for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2014 Moritz Bunkus.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Ingo Ralf Blum.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Ingo Ralf Blum.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/platform/win32/WinIOCallback.cpp
+++ b/src/platform/win32/WinIOCallback.cpp
@@ -1,30 +1,5 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2003 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2002 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/platform/win32/WinIOCallback.h
+++ b/src/platform/win32/WinIOCallback.h
@@ -1,30 +1,6 @@
-/****************************************************************************
-** libebml : parse EBML files, see http://embl.sourceforge.net/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2003 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
-**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2002 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*!
   \file
   \author Steve Lhomme     <robux4 @ users.sf.net>


### PR DESCRIPTION
The copytight date and holder are kept as-is.