### PR TITLE
Add a callback to select which element are written

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -32,9 +32,9 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
 
     bool ValidateSize() const override {return GetSize() < 0x7FFFFFFF;} // we don't mind about what's inside
 
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     void SetBuffer(const binary *Buffer, const std::uint32_t BufferSize) {
       Data = const_cast<binary *>(Buffer);

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -20,9 +20,9 @@ namespace libebml {
 DECLARE_EBML_BINARY(EbmlCrc32)
   public:
     bool ValidateSize() const override {return GetSize() == 4;}
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-//    filepos_t UpdateSize(bool bWithDefault = false);
+//    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault);
 
     bool IsDefaultValue() const override {
       return false;

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -40,7 +40,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
     /*!
       \note no Default date handled
     */
-    filepos_t UpdateSize(bool /* bWithDefault = false */, bool /* bForceRender = false */) override {
+    filepos_t UpdateSize(ShouldWrite /* writeFilter */, bool /* bForceRender = false */) override {
       if(!ValueIsSet())
         SetSize_(0);
       else
@@ -57,7 +57,7 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
     }
 
     private:
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
 
     std::int64_t myDate{0}; ///< internal format of the date
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -13,6 +13,7 @@
 #include "IOCallback.h"
 
 #include <cassert>
+#include <functional>
 
 namespace libebml {
 
@@ -295,7 +296,7 @@ class EBML_DLL_API EbmlElement {
   public:
     // callback to tell if the element should be written or not
     // \return true if the element should be written
-    using ShouldWrite = bool (*)(const EbmlElement &);
+    using ShouldWrite = std::function<bool(const EbmlElement &)>;
 
     // write only elements that don't have their default value set
     static bool WriteSkipDefault(const EbmlElement &elt) {

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -305,7 +305,7 @@ class EBML_DLL_API EbmlElement {
       return true;
     }
 
-    static bool WriteAll(const EbmlElement &elt) {
+    static bool WriteAll(const EbmlElement &) {
       return true;
     }
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -398,7 +398,6 @@ class EBML_DLL_API EbmlElement {
     std::uint64_t VoidMe(IOCallback & output, ShouldWrite writeFilter = WriteSkipDefault) const;
 
     bool DefaultISset() const {return DefaultIsSet;}
-    void ForceNoDefault() {SetDefaultIsSet(false);}
     virtual bool IsDefaultValue() const = 0;
     bool IsFiniteSize() const {return bSizeIsFinite;}
 

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -32,9 +32,9 @@ class EBML_DLL_API EbmlFloat : public EbmlElement {
       return (GetSize() == 4 || GetSize() == 8);
     }
 
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     void SetPrecision(const EbmlFloat::Precision prec = FLOAT_32)
     {

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -39,9 +39,9 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     */
     ~EbmlMaster() override;
 
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     bool PushElement(EbmlElement & element);
     std::uint64_t GetSize() const override {
@@ -129,7 +129,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     /*!
       \brief facility for Master elements to write only the head and force the size later
     */
-    filepos_t WriteHead(IOCallback & output, int SizeLength, bool bWithDefault = false);
+    filepos_t WriteHead(IOCallback & output, int SizeLength, ShouldWrite writeFilter = WriteSkipDefault);
 
     void EnableChecksum(bool bIsEnabled = true) { bChecksumUsed = bIsEnabled; }
     bool HasChecksum() const {return bChecksumUsed;}

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -36,9 +36,9 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
         void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_INT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
     bool ValidateSize() const override {return GetSize() <= 8;}
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     bool IsSmallerThan(const EbmlElement *Cmp) const override;
 

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -25,9 +25,9 @@ class EBML_DLL_API EbmlString : public EbmlElement {
     explicit EbmlString(const EbmlCallbacks &, const std::string & aDefaultValue);
 
     bool ValidateSize() const override {return GetSize() < 0x7FFFFFFF;} // any size is possible
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     EbmlString & operator=(const std::string &);
     using EbmlElement::operator const EbmlId &;

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -34,9 +34,9 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
     void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_UINT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
     bool ValidateSize() const override {return GetSize() <= 8;}
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     bool IsSmallerThan(const EbmlElement *Cmp) const override;
 

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -71,9 +71,9 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElement {
     explicit EbmlUnicodeString(const EbmlCallbacks &, const UTFstring & DefaultValue);
 
     bool ValidateSize() const override {return true;} // any size is possible
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     EbmlUnicodeString & operator=(const UTFstring &); ///< platform dependant code
     using EbmlElement::operator const EbmlId &;

--- a/ebml/EbmlVoid.h
+++ b/ebml/EbmlVoid.h
@@ -23,17 +23,17 @@ DECLARE_EBML_BINARY(EbmlVoid)
     /*!
       \note overwrite to write fake data
     */
-    filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
 
     /*!
       \brief Replace the void element content (written) with this one
     */
-    std::uint64_t ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
+    std::uint64_t ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, ShouldWrite writeFilter = WriteSkipDefault);
 
     /*!
       \brief Void the content of an element
     */
-    std::uint64_t Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
+    std::uint64_t Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, ShouldWrite writeFilter = WriteSkipDefault);
 
         EBML_CONCRETE_CLASS(EbmlVoid)
 };

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -50,7 +50,7 @@ EbmlBinary::~EbmlBinary() {
 EbmlBinary::operator const binary &() const {return *Data;}
 
 
-filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   output.writeFully(Data,GetSize());
 
@@ -60,7 +60,7 @@ filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, b
 /*!
   \note no Default binary value handled
 */
-std::uint64_t EbmlBinary::UpdateSize(bool /* bWithDefault */, bool /* bForceRender */)
+std::uint64_t EbmlBinary::UpdateSize(ShouldWrite /* writeFilter */, bool /* bForceRender */)
 {
   return GetSize();
 }

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -161,7 +161,7 @@ void EbmlCrc32::AddElementCRC32(EbmlElement &ElementToCRC)
 {
   // Use a special IOCallback class that Render's to memory instead of to disk
   MemIOCallback memoryBuffer;
-  ElementToCRC.Render(memoryBuffer, true, true);
+  ElementToCRC.Render(memoryBuffer, WriteAll, true);
 
   const std::uint64_t memSize = memoryBuffer.GetDataBufferSize();
   if (memSize > std::numeric_limits<std::uint32_t>::max())
@@ -183,7 +183,7 @@ bool EbmlCrc32::CheckElementCRC32(EbmlElement &ElementToCRC) const
   return CheckCRC(m_crc_final, memoryBuffer.GetDataBuffer(), static_cast<std::uint32_t>(memSize));
 }
 
-filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   filepos_t Result = 4;
 

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -31,7 +31,7 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
   return GetSize();
 }
 
-filepos_t EbmlDate::RenderData(IOCallback & output, bool /* bForceRender */, bool  /* bWithDefault */)
+filepos_t EbmlDate::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   assert(GetSize() == 8 || GetSize() == 0);
   if (GetSize() == 8) {

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -51,7 +51,7 @@ EbmlFloat & EbmlFloat::SetValue(double NewValue) {
   \todo handle exception on errors
   \todo handle 10 bits precision
 */
-filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   assert(GetSize() == 4 || GetSize() == 8);
 
@@ -74,9 +74,9 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, bo
   return GetSize();
 }
 
-std::uint64_t EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
+std::uint64_t EbmlFloat::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!bWithDefault && IsDefaultValue())
+  if (!writeFilter(*this))
     return 0;
   return GetSize();
 }

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -55,7 +55,7 @@ EbmlSInteger & EbmlSInteger::SetValue(std::int64_t NewValue) {
 /*!
   \todo handle exception on errors
 */
-filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   std::array<binary, 8> FinalData; // we don't handle more than 64 bits integers
   unsigned int i;
@@ -74,9 +74,9 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-std::uint64_t EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlSInteger::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!bWithDefault && IsDefaultValue())
+  if (!writeFilter(*this))
     return 0;
 
   if (Value <= 0x7F && Value >= (-0x80)) {

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -53,7 +53,7 @@ const std::string & EbmlString::DefaultVal() const
 /*!
   \todo handle exception on errors
 */
-filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   filepos_t Result;
   output.writeFully(Value.c_str(), Value.length());
@@ -90,9 +90,9 @@ std::string EbmlString::GetValue() const {
   return Value;
 }
 
-std::uint64_t EbmlString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlString::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!bWithDefault && IsDefaultValue())
+  if (!writeFilter(*this))
     return 0;
 
   if (Value.length() < GetDefaultSize()) {

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -50,7 +50,7 @@ EbmlUInteger & EbmlUInteger::SetValue(std::uint64_t NewValue) {
 /*!
   \todo handle exception on errors
 */
-filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   std::array<binary, 8> FinalData; // we don't handle more than 64 bits integers
 
@@ -68,9 +68,9 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-std::uint64_t EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlUInteger::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!bWithDefault && IsDefaultValue())
+  if (!writeFilter(*this))
     return 0;
 
   if (Value <= 0xFF) {

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -131,7 +131,7 @@ const UTFstring & EbmlUnicodeString::DefaultVal() const
 \note limited to UCS-2
 \todo handle exception on errors
 */
-filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   std::size_t Result = Value.GetUTF8().length();
 
@@ -179,9 +179,9 @@ std::string EbmlUnicodeString::GetValueUTF8() const {
 /*!
 \note limited to UCS-2
 */
-std::uint64_t EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+std::uint64_t EbmlUnicodeString::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!bWithDefault && IsDefaultValue())
+  if (!writeFilter(*this))
     return 0;
 
   SetSize_(Value.GetUTF8().length());

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -18,7 +18,7 @@ EbmlVoid::EbmlVoid()
   SetValueIsSet();
 }
 
-filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
 {
   // write dummy data by 4KB chunks
   static binary DummyBuf[4*1024];
@@ -32,9 +32,9 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, boo
   return GetSize();
 }
 
-std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
+std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, ShouldWrite writeFilter)
 {
-  EltToReplaceWith.UpdateSize(bWithDefault);
+  EltToReplaceWith.UpdateSize(writeFilter);
   if (HeadSize() + GetSize() < EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize()) {
     // the element can't be written here !
     return INVALID_FILEPOS_T;
@@ -47,7 +47,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   const std::uint64_t CurrentPosition = output.getFilePointer();
 
   output.setFilePointer(GetElementPosition());
-  EltToReplaceWith.Render(output, bWithDefault);
+  EltToReplaceWith.Render(output, writeFilter);
 
   if (HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize() > 1) {
     // fill the rest with another void element
@@ -59,7 +59,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
     if (HeadBefore != HeadAfter) {
       aTmp.SetSizeLength(CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength()) - (HeadAfter - HeadBefore));
     }
-    aTmp.RenderHead(output, false, bWithDefault); // the rest of the data is not rewritten
+    aTmp.RenderHead(output, false, writeFilter); // the rest of the data is not rewritten
   }
 
   if (ComeBackAfterward) {
@@ -69,7 +69,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   return GetSize() + HeadSize();
 }
 
-std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
+std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, ShouldWrite writeFilter)
 {
   //  EltToVoid.UpdateSize(bWithDefault);
   if (EltToVoid.GetElementPosition() == 0) {
@@ -97,7 +97,7 @@ std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & ou
   }
 
   if (GetSize() != 0) {
-    RenderHead(output, false, bWithDefault); // the rest of the data is not rewritten
+    RenderHead(output, false, writeFilter); // the rest of the data is not rewritten
   }
 
   if (ComeBackAfterward) {


### PR DESCRIPTION
And remove the ForceNoDefault() which is not needed anymore.

There's a `EBML_WRITE_FILTER` define to tell between libmatroska versions with this feature or not.