### PR TITLE
Rework UTFString API to only keep UTF-8

### DIFF
--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -41,8 +41,8 @@ public:
   UTFstring & operator=(const wchar_t *);
   UTFstring & operator=(wchar_t);
 
-  /// Return length of string
-  std::size_t length() const {return WString.size();}
+  /// Return length of string in bytes not counting the trailing nul character
+  std::size_t length() const {return UTF8string.length();}
 
   explicit operator const wchar_t*() const {return WString.c_str();};
   const wchar_t* c_str() const {return WString.c_str();}

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -19,21 +19,28 @@ namespace libebml {
 
 /*!
   \class UTFstring
-  A class storing strings in a wchar_t (ie, in UCS-2 or UCS-4)
-  \note inspired by wstring which is not available everywhere
+  A class storing strings in a char that can receive wchar_t (ie, in UCS-2 or UCS-4)
 */
 class EBML_DLL_API UTFstring {
 public:
-  using value_type = wchar_t;
+  using value_type = char;
 
   UTFstring() = default;
-  UTFstring(const wchar_t *); // should be NULL terminated
+  UTFstring(const char *); // should be NULL terminated
   UTFstring(const UTFstring &) = default;
   UTFstring(std::wstring const &);
 
   virtual ~UTFstring() = default;
   bool operator==(const UTFstring&) const;
+  inline bool operator==(const wchar_t *cmp) const
+  {
+    return *this == UTFstring(std::wstring{cmp});
+  }
   inline bool operator!=(const UTFstring &cmp) const
+  {
+    return !(*this == cmp);
+  }
+  inline bool operator!=(const wchar_t *cmp) const
   {
     return !(*this == cmp);
   }
@@ -44,17 +51,12 @@ public:
   /// Return length of string in bytes not counting the trailing nul character
   std::size_t length() const {return UTF8string.length();}
 
-  explicit operator const wchar_t*() const {return WString.c_str();};
-  const wchar_t* c_str() const {return WString.c_str();}
-
   const std::string & GetUTF8() const {return UTF8string;}
   void SetUTF8(const std::string &);
 
 private:
-  std::wstring WString; ///< internal UCS representation
   std::string UTF8string;
-  void UpdateFromUTF8();
-  void UpdateFromUCS2();
+  void UpdateFromUCS2(const std::wstring &);
 };
 
 

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -28,7 +28,7 @@ public:
 
   UTFstring() = default;
   UTFstring(const wchar_t *); // should be NULL terminated
-  UTFstring(const UTFstring &);
+  UTFstring(const UTFstring &) = default;
   UTFstring(std::wstring const &);
 
   virtual ~UTFstring() = default;
@@ -37,7 +37,7 @@ public:
   {
     return !(*this == cmp);
   }
-  UTFstring & operator=(const UTFstring &);
+  UTFstring & operator=(const UTFstring &) = default;
   UTFstring & operator=(const wchar_t *);
   UTFstring & operator=(wchar_t);
 

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -39,17 +39,6 @@ UTFstring::UTFstring(std::wstring const &_aBuf)
   *this = _aBuf.c_str();
 }
 
-UTFstring::UTFstring(const UTFstring & _aBuf)
-{
-  *this = _aBuf.c_str();
-}
-
-UTFstring & UTFstring::operator=(const UTFstring & _aBuf)
-{
-  *this = _aBuf.c_str();
-  return *this;
-}
-
 UTFstring & UTFstring::operator=(const wchar_t * _aBuf)
 {
   if (_aBuf != nullptr)

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -53,9 +53,15 @@ UTFstring & UTFstring::operator=(const UTFstring & _aBuf)
 UTFstring & UTFstring::operator=(const wchar_t * _aBuf)
 {
   if (_aBuf != nullptr)
+  {
     WString = _aBuf;
+    UpdateFromUCS2();
+  }
   else
+  {
     WString.clear();
+    UTF8string.clear();
+  }
 
   UpdateFromUCS2();
   return *this;

--- a/test/test_utfstring.cxx
+++ b/test/test_utfstring.cxx
@@ -27,8 +27,8 @@ int main(void)
     if (utf8 != emoji_w)
         return 1;
 
-    // UTFstring invalid;
-    // FIXME don't crash invalid.SetUTF8( "\x1\xF6\x00" );
+    UTFstring invalid;
+    invalid.SetUTF8( "\x1\xF6\x00" );
 
     UTFstring empty{0};
     if (empty.length() != 0)

--- a/test/test_utfstring.cxx
+++ b/test/test_utfstring.cxx
@@ -15,9 +15,6 @@ int main(void)
     if (ascii != L"latin1")
         return 1;
 
-    if (wcscmp(ascii.c_str(), L"latin1") != 0)
-        return 1;
-
     if (ascii.GetUTF8() != "latin1")
         return 1;
 
@@ -51,14 +48,8 @@ int main(void)
     if (copy != emoji_w)
         return 1;
 
-    if (copy.c_str() == utf8.c_str())
-        return 1;
-
     UTFstring copy2(utf8);
     if (copy2 != emoji_w)
-        return 1;
-
-    if (copy2.c_str() == utf8.c_str())
         return 1;
 
     return 0;

--- a/test/test_utfstring.cxx
+++ b/test/test_utfstring.cxx
@@ -24,7 +24,7 @@ int main(void)
     UTFstring utf8;
     utf8.SetUTF8( emoji_8 );
 
-    if (utf8.length() != (4 / sizeof(wchar_t)))
+    if (utf8.length() != 4)
         return 1;
 
     if (utf8 != emoji_w)
@@ -45,7 +45,7 @@ int main(void)
         return 1;
 
     UTFstring copy = utf8;
-    if (copy.length() != (4 / sizeof(wchar_t)))
+    if (copy.length() != 4)
         return 1;
 
     if (copy != emoji_w)

--- a/test/test_utfstring.cxx
+++ b/test/test_utfstring.cxx
@@ -6,6 +6,7 @@
 using namespace libebml;
 
 constexpr char emoji_8[] = "\xF0\x9F\x98\x80";
+constexpr char emoji_u8[] = u8"\xF0\x9F\x98\x80";
 constexpr wchar_t emoji_w[] = L"\U0001f600";
 
 int main(void)
@@ -17,6 +18,11 @@ int main(void)
 
     if (ascii.GetUTF8() != "latin1")
         return 1;
+
+    UTFstring u8;
+    u8.SetUTF8( emoji_u8 );
+
+    UTFstring u8construct{emoji_u8};
 
     UTFstring utf8;
     utf8.SetUTF8( emoji_8 );


### PR DESCRIPTION
In EBML and in most systems, UTF-8 is used by default. Converting from wchar_t should be the exception and not done for every unicode string we read/write.

**Some API's with wchar_t are gone**. They are not used in VLC (which just deals wtih UTF-8) and in some corresponding `to_wide` functions in mkvtoolnix seem to be unused and can also be removed.

**The length() reported is different.** It now reports the length in bytes of the UTF-8 string which is the length needed to write the buffer in EBML anyway.

This PR also fixes #180.