### PR TITLE
Use templates for the base types to factorize code

### DIFF
--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -17,9 +17,16 @@ namespace libebml {
     \class EbmlDate
     \brief Handle all operations related to an EBML date
 */
-class EBML_DLL_API EbmlDate : public EbmlElement {
+class EBML_DLL_API EbmlDate : public EbmlElementDefault<std::int64_t> {
   public:
-    EbmlDate(const EbmlCallbacks & classInfo) :EbmlElement(classInfo, 8, false) {}
+    EbmlDate(const EbmlCallbacksDefault<std::int64_t> & classInfo) :EbmlElementDefault<std::int64_t>(classInfo, 8)
+    {
+      if (classInfo.HasDefault())
+      {
+        auto def = static_cast<const EbmlCallbacksWithDefault<std::int64_t> &>(classInfo);
+        SetValue(def.DefaultValue());
+      }
+    }
 
     /*!
       \brief set the date with a UNIX/C/EPOCH form
@@ -52,8 +59,8 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
 
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
 
-    bool IsDefaultValue() const override {
-      return false;
+    bool operator==(const std::int64_t & val) const override {
+      return val == Value;
     }
 
     private:

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -325,6 +325,8 @@ class EBML_DLL_API EbmlElement {
     virtual ~EbmlElement() = default;
     EbmlElement& operator=(const EbmlElement&) = delete;
 
+    const EbmlCallbacks & ElementSpec() const { return ClassInfo; }
+
     /// Set the minimum length that will be used to write the element size (-1 = optimal)
     void SetSizeLength(int NewSizeLength) {SizeLength = NewSizeLength;}
     int GetSizeLength() const {return SizeLength;}

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -17,15 +17,14 @@ namespace libebml {
     \class EbmlFloat
     \brief Handle all operations on a float EBML element
 */
-class EBML_DLL_API EbmlFloat : public EbmlElement {
+class EBML_DLL_API EbmlFloat : public EbmlElementDefault<double> {
   public:
     enum Precision {
        FLOAT_32
       ,FLOAT_64
     };
 
-    EbmlFloat(const EbmlCallbacks &, Precision prec = FLOAT_32);
-    EbmlFloat(const EbmlCallbacks &, double DefaultValue, Precision prec = FLOAT_32);
+    EbmlFloat(const EbmlCallbacksDefault<double> &, Precision prec = FLOAT_32);
 
     bool ValidateSize() const override
     {
@@ -54,17 +53,12 @@ class EBML_DLL_API EbmlFloat : public EbmlElement {
     EbmlFloat &SetValue(double NewValue);
     double GetValue() const;
 
-    void SetDefaultValue(double);
-
-    double DefaultVal() const;
-
-    bool IsDefaultValue() const override {
-      return (DefaultISset() && Value == DefaultValue);
+    bool operator==(const double & val) const override {
+      return val == Value;
     }
 
     private:
     double Value; /// The actual value of the element
-    double DefaultValue;
 };
 
 } // namespace libebml

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -23,10 +23,9 @@ const int DEFAULT_INT_SIZE = 1; ///< optimal size stored
     \class EbmlSInteger
     \brief Handle all operations on a signed integer EBML element
 */
-class EBML_DLL_API EbmlSInteger : public EbmlElement {
+class EBML_DLL_API EbmlSInteger : public EbmlElementDefault<std::int64_t> {
   public:
-    EbmlSInteger(const EbmlCallbacks &);
-    explicit EbmlSInteger(const EbmlCallbacks &, std::int64_t DefaultValue);
+    EbmlSInteger(const EbmlCallbacksDefault<std::int64_t> &);
 
     /*!
       Set the default size of the integer (usually 1,2,4 or 8)
@@ -49,17 +48,12 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
     EbmlSInteger &SetValue(std::int64_t NewValue);
     std::int64_t GetValue() const;
 
-    void SetDefaultValue(std::int64_t aValue) {assert(!DefaultISset()); DefaultValue = aValue; SetDefaultIsSet();}
-
-    std::int64_t DefaultVal() const {assert(DefaultISset()); return DefaultValue;}
-
-    bool IsDefaultValue() const override {
-      return (DefaultISset() && Value == DefaultValue);
+    bool operator==(const std::int64_t & val) const override {
+      return val == Value;
     }
 
     private:
     std::int64_t Value; /// The actual value of the element
-    std::int64_t DefaultValue;
 };
 
 } // namespace libebml

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -19,10 +19,9 @@ namespace libebml {
     \class EbmlString
     \brief Handle all operations on a printable string EBML element
 */
-class EBML_DLL_API EbmlString : public EbmlElement {
+class EBML_DLL_API EbmlString : public EbmlElementDefault<const char *> {
   public:
-    EbmlString(const EbmlCallbacks &);
-    explicit EbmlString(const EbmlCallbacks &, const std::string & aDefaultValue);
+    EbmlString(const EbmlCallbacksDefault<const char *> &);
 
     bool ValidateSize() const override {return GetSize() < 0x7FFFFFFF;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
@@ -35,17 +34,12 @@ class EBML_DLL_API EbmlString : public EbmlElement {
     EbmlString &SetValue(std::string const &NewValue);
     std::string GetValue() const;
 
-    void SetDefaultValue(std::string &);
-
-    const std::string & DefaultVal() const;
-
-    bool IsDefaultValue() const override {
-      return (DefaultISset() && Value == DefaultValue);
+    bool operator==(const char * const & val) const override {
+      return val == Value;
     }
 
     private:
     std::string Value;  /// The actual value of the element
-    std::string DefaultValue;
 };
 
 } // namespace libebml

--- a/ebml/EbmlSubHead.h
+++ b/ebml/EbmlSubHead.h
@@ -15,37 +15,37 @@
 
 namespace libebml {
 
-DECLARE_EBML_UINTEGER(EVersion)
+DECLARE_EBML_UINTEGER_DEF(EVersion)
   public:
         EBML_CONCRETE_CLASS(EVersion)
 };
 
-DECLARE_EBML_UINTEGER(EReadVersion)
+DECLARE_EBML_UINTEGER_DEF(EReadVersion)
   public:
         EBML_CONCRETE_CLASS(EReadVersion)
 };
 
-DECLARE_EBML_UINTEGER(EMaxIdLength)
+DECLARE_EBML_UINTEGER_DEF(EMaxIdLength)
   public:
         EBML_CONCRETE_CLASS(EMaxIdLength)
 };
 
-DECLARE_EBML_UINTEGER(EMaxSizeLength)
+DECLARE_EBML_UINTEGER_DEF(EMaxSizeLength)
   public:
         EBML_CONCRETE_CLASS(EMaxSizeLength)
 };
 
-DECLARE_EBML_STRING(EDocType)
+DECLARE_EBML_STRING_DEF(EDocType)
   public:
         EBML_CONCRETE_CLASS(EDocType)
 };
 
-DECLARE_EBML_UINTEGER(EDocTypeVersion)
+DECLARE_EBML_UINTEGER_DEF(EDocTypeVersion)
   public:
         EBML_CONCRETE_CLASS(EDocTypeVersion)
 };
 
-DECLARE_EBML_UINTEGER(EDocTypeReadVersion)
+DECLARE_EBML_UINTEGER_DEF(EDocTypeReadVersion)
   public:
         EBML_CONCRETE_CLASS(EDocTypeReadVersion)
 };

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -21,10 +21,9 @@ const int DEFAULT_UINT_SIZE = 0; ///< optimal size stored
     \class EbmlUInteger
     \brief Handle all operations on an unsigned integer EBML element
 */
-class EBML_DLL_API EbmlUInteger : public EbmlElement {
+class EBML_DLL_API EbmlUInteger : public EbmlElementDefault<std::uint64_t> {
   public:
-    EbmlUInteger(const EbmlCallbacks &);
-    explicit EbmlUInteger(const EbmlCallbacks &, std::uint64_t DefaultValue);
+    EbmlUInteger(const EbmlCallbacksDefault<std::uint64_t> &);
 
     /*!
       Set the default size of the integer (usually 1,2,4 or 8)
@@ -47,17 +46,12 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
     EbmlUInteger &SetValue(std::uint64_t NewValue);
     std::uint64_t GetValue() const;
 
-    void SetDefaultValue(std::uint64_t);
-
-    std::uint64_t DefaultVal() const;
-
-    bool IsDefaultValue() const override {
-      return (DefaultISset() && Value == DefaultValue);
+    bool operator==(const std::uint64_t & val) const override {
+      return val == Value;
     }
 
     private:
     std::uint64_t Value; /// The actual value of the element
-    std::uint64_t DefaultValue;
 };
 
 } // namespace libebml

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -65,10 +65,9 @@ private:
     \brief Handle all operations on a Unicode string EBML element
   \note internally treated as a string made of wide characters (ie UCS-2 or UCS-4 depending on the machine)
 */
-class EBML_DLL_API EbmlUnicodeString : public EbmlElement {
+class EBML_DLL_API EbmlUnicodeString : public EbmlElementDefault<const wchar_t *> {
   public:
-    EbmlUnicodeString(const EbmlCallbacks &);
-    explicit EbmlUnicodeString(const EbmlCallbacks &, const UTFstring & DefaultValue);
+    EbmlUnicodeString(const EbmlCallbacksDefault<const wchar_t *> &);
 
     bool ValidateSize() const override {return true;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
@@ -83,17 +82,12 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElement {
     UTFstring GetValue() const;
     std::string GetValueUTF8() const;
 
-    void SetDefaultValue(UTFstring &);
-
-    const UTFstring & DefaultVal() const;
-
-    bool IsDefaultValue() const override {
-      return (DefaultISset() && Value == DefaultValue);
+    bool operator==(const wchar_t * const & val) const override {
+      return static_cast<UTFstring>(val) == Value;
     }
 
     private:
     UTFstring Value; /// The actual value of the element
-    UTFstring DefaultValue;
 };
 
 } // namespace libebml

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -12,30 +12,15 @@
 
 namespace libebml {
 
-EbmlFloat::EbmlFloat(const EbmlCallbacks & classInfo, const EbmlFloat::Precision prec)
-  :EbmlElement(classInfo, 0, false)
+EbmlFloat::EbmlFloat(const EbmlCallbacksDefault<double> & classInfo, const EbmlFloat::Precision prec)
+  :EbmlElementDefault(classInfo, 0)
 {
   SetPrecision(prec);
-}
-
-EbmlFloat::EbmlFloat(const EbmlCallbacks & classInfo, const double aDefaultValue, const EbmlFloat::Precision prec)
-  :EbmlElement(classInfo, 0, true), Value(aDefaultValue), DefaultValue(aDefaultValue)
-{
-  SetDefaultIsSet();
-  SetPrecision(prec);
-}
-
-void EbmlFloat::SetDefaultValue(double aValue)
-{
-  assert(!DefaultISset());
-  DefaultValue = aValue;
-  SetDefaultIsSet();
-}
-
-double EbmlFloat::DefaultVal() const
-{
-  assert(DefaultISset());
-  return DefaultValue;
+  if (classInfo.HasDefault())
+  {
+    auto def = static_cast<const EbmlCallbacksWithDefault<double> &>(classInfo);
+    SetValue(def.DefaultValue());
+  }
 }
 
 EbmlFloat::operator float() const {return static_cast<float>(Value);}

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -170,13 +170,12 @@ bool EbmlMaster::CheckMandatory() const
   for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {
       if (FindElt(EBML_CTX_IDX_INFO(MasterContext,EltIdx)) == nullptr) {
-        const auto testElement = &EBML_CTX_IDX(MasterContext,EltIdx).Create();
-        const bool hasDefaultValue = testElement->DefaultISset();
-        delete testElement;
+        const auto & semcb = EBML_CTX_IDX(MasterContext,EltIdx).GetCallbacks();
+        const bool hasDefaultValue = semcb.HasDefault();
 
 #if !defined(NDEBUG)
         // you are missing this Mandatory element
-//         const char * MissingName = EBML_INFO_NAME(EBML_CTX_IDX_INFO(MasterContext,EltIdx));
+//         const char * MissingName = semcb.GetName();
 #endif // !NDEBUG
         if (!hasDefaultValue)
           return false;

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -31,14 +31,14 @@ ToSigned(std::uint64_t u) {
 
 namespace libebml {
 
-EbmlSInteger::EbmlSInteger(const EbmlCallbacks & classInfo)
-  :EbmlElement(classInfo, DEFAULT_INT_SIZE, false)
-{}
-
-EbmlSInteger::EbmlSInteger(const EbmlCallbacks & classInfo, std::int64_t aDefaultValue)
-  :EbmlElement(classInfo, DEFAULT_INT_SIZE, true), Value(aDefaultValue)
+EbmlSInteger::EbmlSInteger(const EbmlCallbacksDefault<std::int64_t> & classInfo)
+  :EbmlElementDefault(classInfo, DEFAULT_INT_SIZE)
 {
-  SetDefaultIsSet();
+  if (classInfo.HasDefault())
+  {
+    auto def = static_cast<const EbmlCallbacksWithDefault<std::int64_t> &>(classInfo);
+    SetValue(def.DefaultValue());
+  }
 }
 
 EbmlSInteger::operator std::int8_t() const {return  static_cast<std::int8_t>(Value);}

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -12,43 +12,15 @@
 
 namespace libebml {
 
-EbmlString::EbmlString(const EbmlCallbacks & classInfo)
-  :EbmlElement(classInfo, 0, false)
+EbmlString::EbmlString(const EbmlCallbacksDefault<const char *> & classInfo)
+  :EbmlElementDefault(classInfo, 0)
 {
-  SetDefaultSize(0);
-/* done automatically
-  SetSize_(Value.length());
-  if (GetDefaultSize() > GetSize())
-    SetSize_(GetDefaultSize());*/
+  if (classInfo.HasDefault())
+  {
+    auto def = static_cast<const EbmlCallbacksWithDefault<const char *> &>(classInfo);
+    SetValue(def.DefaultValue());
+  }
 }
-
-EbmlString::EbmlString(const EbmlCallbacks & classInfo, const std::string & aDefaultValue)
-  :EbmlElement(classInfo, 0, true), Value(aDefaultValue), DefaultValue(aDefaultValue)
-{
-  SetDefaultSize(0);
-  SetDefaultIsSet();
-/* done automatically
-  SetSize_(Value.length());
-  if (GetDefaultSize() > GetSize())
-    SetSize_(GetDefaultSize());*/
-}
-
-/*!
-  \todo Cloning should be on the same exact type !
-*/
-void EbmlString::SetDefaultValue(std::string & aValue)
-{
-  assert(!DefaultISset());
-  DefaultValue = aValue;
-  SetDefaultIsSet();
-}
-
-const std::string & EbmlString::DefaultVal() const
-{
-  assert(DefaultISset());
-  return DefaultValue;
-}
-
 
 /*!
   \todo handle exception on errors

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -13,27 +13,14 @@
 
 namespace libebml {
 
-EbmlUInteger::EbmlUInteger(const EbmlCallbacks & classInfo)
-  :EbmlElement(classInfo, DEFAULT_UINT_SIZE, false)
-{}
-
-EbmlUInteger::EbmlUInteger(const EbmlCallbacks & classInfo, std::uint64_t aDefaultValue)
-  :EbmlElement(classInfo, DEFAULT_UINT_SIZE, true), Value(aDefaultValue), DefaultValue(aDefaultValue)
+EbmlUInteger::EbmlUInteger(const EbmlCallbacksDefault<std::uint64_t> & classInfo)
+  :EbmlElementDefault(classInfo, DEFAULT_UINT_SIZE)
 {
-  SetDefaultIsSet();
-}
-
-void EbmlUInteger::SetDefaultValue(std::uint64_t aValue)
-{
-  assert(!DefaultISset());
-  DefaultValue = aValue;
-  SetDefaultIsSet();
-}
-
-std::uint64_t EbmlUInteger::DefaultVal() const
-{
-  assert(DefaultISset());
-  return DefaultValue;
+  if (classInfo.HasDefault())
+  {
+    auto def = static_cast<const EbmlCallbacksWithDefault<std::uint64_t> &>(classInfo);
+    SetValue(def.DefaultValue());
+  }
 }
 
 EbmlUInteger::operator std::uint8_t()  const {return static_cast<std::uint8_t>(Value); }

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -100,32 +100,15 @@ void UTFstring::UpdateFromUCS2(const std::wstring & WString)
 
 // ===================== EbmlUnicodeString class ===================
 
-EbmlUnicodeString::EbmlUnicodeString(const EbmlCallbacks & classInfo)
-  :EbmlElement(classInfo, 0, false)
+EbmlUnicodeString::EbmlUnicodeString(const EbmlCallbacksDefault<const wchar_t *> & classInfo)
+  :EbmlElementDefault(classInfo, 0)
 {
-  SetDefaultSize(0);
+  if (classInfo.HasDefault())
+  {
+    auto def = static_cast<const EbmlCallbacksWithDefault<const wchar_t *> &>(classInfo);
+    SetValue(UTFstring{def.DefaultValue()});
+  }
 }
-
-EbmlUnicodeString::EbmlUnicodeString(const EbmlCallbacks & classInfo, const UTFstring & aDefaultValue)
-  :EbmlElement(classInfo, 0, true), Value(aDefaultValue), DefaultValue(aDefaultValue)
-{
-  SetDefaultSize(0);
-  SetDefaultIsSet();
-}
-
-void EbmlUnicodeString::SetDefaultValue(UTFstring & aValue)
-{
-  assert(!DefaultISset());
-  DefaultValue = aValue;
-  SetDefaultIsSet();
-}
-
-const UTFstring & EbmlUnicodeString::DefaultVal() const
-{
-  assert(DefaultISset());
-  return DefaultValue;
-}
-
 
 /*!
 \note limited to UCS-2

--- a/test/test_infinite.cxx
+++ b/test/test_infinite.cxx
@@ -7,7 +7,7 @@
 
 using namespace libebml;
 
-DECLARE_xxx_UINTEGER(DummyChild,)
+DECLARE_xxx_UINTEGER_DEF(DummyChild,)
 EBML_CONCRETE_CLASS(DummyChild)
 };
 

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -5,39 +5,59 @@
 
 using namespace libebml;
 
-DECLARE_EBML_STRING(StringWithDefault)
+DECLARE_EBML_STRING_DEF(StringWithDefault)
     EBML_CONCRETE_CLASS(StringWithDefault)
 };
 DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, 2, EbmlHead, "StringWithDefault", "Default Value")
 
-DECLARE_EBML_STRING(StringWithoutDefault)
+DECLARE_xxx_STRING(StringWithoutDefault,)
     EBML_CONCRETE_CLASS(StringWithoutDefault)
 };
 DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, 2, EbmlHead, "StringWithoutDefault", GetEbmlGlobal_Context)
 
-DECLARE_xxx_UNISTRING(UniStringWithDefault,)
+DECLARE_xxx_UNISTRING_DEF(UniStringWithDefault,)
     EBML_CONCRETE_CLASS(UniStringWithDefault)
 };
-DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, 2, EbmlHead, "UniStringWithDefault", GetEbmlGlobal_Context, UTFstring{L"Default Value"})
+DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, 2, EbmlHead, "UniStringWithDefault", GetEbmlGlobal_Context, L"Default Value")
 
 DECLARE_xxx_UNISTRING(UniStringWithoutDefault,)
     EBML_CONCRETE_CLASS(UniStringWithoutDefault)
 };
 DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, 2, EbmlHead, "UniStringWithoutDefault", GetEbmlGlobal_Context)
 
-DECLARE_EBML_UINTEGER(UIntWithDefault)
+DECLARE_EBML_UINTEGER_DEF(UIntWithDefault)
     EBML_CONCRETE_CLASS(UIntWithDefault)
 };
 DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, 3, EbmlHead, "UIntWithDefault", 42)
 
-DECLARE_EBML_UINTEGER(UIntWithoutDefault)
+DECLARE_xxx_UINTEGER(UIntWithoutDefault,)
     EBML_CONCRETE_CLASS(UIntWithoutDefault)
 };
 DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, 3, EbmlHead, "UIntWithoutDefault", GetEbmlGlobal_Context)
 
 int main(void)
 {
+    if (!StringWithDefault::ClassInfo().HasDefault())
+        return 1;
+    if (StringWithoutDefault::ClassInfo().HasDefault())
+        return 1;
+    if (!UniStringWithDefault::ClassInfo().HasDefault())
+        return 1;
+    if (UniStringWithoutDefault::ClassInfo().HasDefault())
+        return 1;
+    if (!UIntWithDefault::ClassInfo().HasDefault())
+        return 1;
+    if (UIntWithoutDefault::ClassInfo().HasDefault())
+        return 1;
+
+    if (UIntWithDefault::GetElementSpec().DefaultValue() != 42)
+        return 1;
+
     UIntWithDefault test0;
+    auto ClassSpecWithDefault = test0.ElementSpec();
+    if (!ClassSpecWithDefault.HasDefault())
+        return 1;
+
     test0.SetValue(0);
     if (test0.IsDefaultValue())
         return 1;
@@ -47,7 +67,10 @@ int main(void)
     if (!test42.IsDefaultValue())
         return 1;
 
-    if (!test42.DefaultISset())
+    if (!test42.ElementSpec().HasDefault())
+        return 1;
+
+    if (test42.ElementSpec().DefaultValue() != 42)
         return 1;
 
     uint64_t val = static_cast<uint64_t>(test42);
@@ -64,11 +87,22 @@ int main(void)
     if (!test42.IsDefaultValue())
         return 1;
 
+    UIntWithoutDefault testNoDefault0;
+    auto ClassSpecWithoutDefault = testNoDefault0.ElementSpec();
+    if (ClassSpecWithoutDefault.HasDefault())
+        return 1;
+#ifdef TEST_COMPILATION_ERRORS
+    if (ClassSpecWithoutDefault.DefaultValue())
+        return 1;
+#else
+    (void)ClassSpecWithoutDefault;
+#endif
+
     StringWithDefault strdef;
     if (!strdef.IsDefaultValue())
         return 1;
 
-    if (!strdef.DefaultISset())
+    if (!strdef.GetElementSpec().HasDefault())
         return 1;
 
     strdef.SetValue("Other");
@@ -83,7 +117,7 @@ int main(void)
     if (strnodef.IsDefaultValue())
         return 1;
 
-    if (strnodef.DefaultISset())
+    if (strnodef.GetElementSpec().HasDefault())
         return 1;
 
     strnodef.SetValue("Other");
@@ -95,14 +129,14 @@ int main(void)
         return 1;
 
     EbmlElement & genericdef = test42;
-    if (!genericdef.DefaultISset())
+    if (!genericdef.ElementSpec().HasDefault())
         return 1;
 
     if (!genericdef.IsDefaultValue())
         return 1;
 
     EbmlElement & genericnodef = strnodef;
-    if (genericnodef.DefaultISset())
+    if (genericnodef.ElementSpec().HasDefault())
         return 1;
 
     if (genericnodef.IsDefaultValue())


### PR DESCRIPTION
A lot of the logic is the same between classes. We can factorize the code once we have factorized the storage (and initialization) types in a template.

The default value is moved to a EbmlCallbacksDefault class for the types that can have a default value. So the default value is not copied in each instance of every object.

~~This was done on top of #173 but maybe it works on its own.~~