### PR TITLE
fix exported context const

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -51,7 +51,7 @@ class EbmlSemanticContext;
 class EbmlElement;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
-    constexpr EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
+    constexpr const EbmlSemanticContext Context_##x = EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,global) \
     constexpr EbmlId Id_##x    (id, idl); \


### PR DESCRIPTION
Changed after d6dc50cee690491a2aa8e038e31f2cdc2001c24a.

libmatroska currently doesn't build without this.