### PR TITLE
Use shared_ptr for the internal MemReadIOCallback of SafeReadIOCallback

### DIFF
--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -12,6 +12,8 @@
 #include "EbmlTypes.h"
 #include "IOCallback.h"
 
+#include <memory>
+
 namespace libebml {
 
 class EBML_DLL_API SafeReadIOCallback : public std::exception {
@@ -23,15 +25,14 @@ public:
   };
 
 private:
-  IOCallback *mIO;
-  bool mDeleteIO;
+  std::shared_ptr<IOCallback> mIO;
   std::size_t mSize;
 
 public:
-  SafeReadIOCallback(IOCallback *IO, bool DeleteIO);
+  SafeReadIOCallback(std::shared_ptr<IOCallback> &IO);
   SafeReadIOCallback(void const *Mem, std::size_t Size);
   explicit SafeReadIOCallback(EbmlBinary const &Binary);
-  ~SafeReadIOCallback() override;
+  ~SafeReadIOCallback() override = default;
   SafeReadIOCallback(const SafeReadIOCallback&) = delete;
   SafeReadIOCallback& operator=(const SafeReadIOCallback&) = delete;
 
@@ -53,7 +54,7 @@ public:
   void Seek(std::size_t Position);
 
 protected:
-  void Init(IOCallback *IO, bool DeleteIO);
+  void Init(std::shared_ptr<IOCallback> &IO);
 };
 
 } // namespace libebml

--- a/src/SafeReadIOCallback.cpp
+++ b/src/SafeReadIOCallback.cpp
@@ -22,30 +22,24 @@ SafeReadIOCallback::EndOfStreamX::EndOfStreamX(std::size_t MissingBytes)
 
 // ----------------------------------------------------------------------
 
-SafeReadIOCallback::SafeReadIOCallback(IOCallback *IO,
-                                       bool DeleteIO) {
-  Init(IO, DeleteIO);
+SafeReadIOCallback::SafeReadIOCallback(std::shared_ptr<IOCallback> & IO) {
+  Init(IO);
 }
 
 SafeReadIOCallback::SafeReadIOCallback(void const *Mem,
                                        std::size_t Size) {
-  Init(new MemReadIOCallback(Mem, Size), true);
+  std::shared_ptr<IOCallback> t = std::make_shared<MemReadIOCallback>(Mem, Size);
+  Init(t);
 }
 
 SafeReadIOCallback::SafeReadIOCallback(EbmlBinary const &Binary) {
-  Init(new MemReadIOCallback(Binary), true);
-}
-
-SafeReadIOCallback::~SafeReadIOCallback() {
-  if (mDeleteIO)
-    delete mIO;
+  std::shared_ptr<IOCallback> t = std::make_shared<MemReadIOCallback>(Binary);
+  Init(t);
 }
 
 void
-SafeReadIOCallback::Init(IOCallback *IO,
-                         bool DeleteIO) {
+SafeReadIOCallback::Init(std::shared_ptr<IOCallback> & IO) {
   mIO                = IO;
-  mDeleteIO          = DeleteIO;
   const std::int64_t PrevPosition = IO->getFilePointer();
   IO->setFilePointer(0, seek_end);
   mSize              = IO->getFilePointer();


### PR DESCRIPTION
This class is only used by libmatroska to wrap an  EbmlBinary. So the API changes will have no impact on external code.