### PR TITLE
Move some common virtual methods in EbmlElement

### DIFF
--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -23,8 +23,6 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
       return DummyId;
     }
 
-    const EbmlSemanticContext &Context() const override;
-    const char *DebugName() const override { return "DummyElement"; }
     EbmlElement & CreateElement() const override { return Create(); }
     EbmlElement * Clone() const override { return new EbmlDummy(DummyId); }
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -162,9 +162,6 @@ class EbmlElement;
 
 #define EBML_CONCRETE_CLASS(Type) \
     public: \
-        const libebml::EbmlSemanticContext &Context() const override {return ClassInfos.GetContext();} \
-        const char *DebugName() const override {return ClassInfos.GetName();} \
-        libebml::EbmlId const &GetClassId() const override {return ClassInfos.ClassId();} \
         libebml::EbmlElement & CreateElement() const override {return Create();} \
         libebml::EbmlElement * Clone() const override { return new Type(*this); } \
     static libebml::EbmlElement & Create() {return *(new Type);} \
@@ -332,10 +329,10 @@ class EBML_DLL_API EbmlElement {
     */
     virtual EbmlElement * Clone() const = 0;
 
-    virtual EbmlId const &GetClassId() const = 0;
+    virtual EbmlId const &GetClassId() const {return ClassInfo.ClassId();}
     virtual explicit operator const EbmlId &() const { return GetClassId(); }
-        virtual const char *DebugName() const = 0;
-        virtual const EbmlSemanticContext &Context() const = 0;
+        virtual const char *DebugName() const {return ClassInfo.GetName();}
+        virtual const EbmlSemanticContext &Context() const {return ClassInfo.GetContext();}
         virtual EbmlElement & CreateElement() const = 0;
 
     /*!

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -331,8 +331,8 @@ class EBML_DLL_API EbmlElement {
 
     virtual EbmlId const &GetClassId() const {return ClassInfo.ClassId();}
     virtual explicit operator const EbmlId &() const { return GetClassId(); }
-        virtual const char *DebugName() const {return ClassInfo.GetName();}
-        virtual const EbmlSemanticContext &Context() const {return ClassInfo.GetContext();}
+    const char *DebugName() const {return ClassInfo.GetName();}
+    const EbmlSemanticContext &Context() const {return ClassInfo.GetContext();}
         virtual EbmlElement & CreateElement() const = 0;
 
     /*!

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -14,9 +14,4 @@ DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, 1, "DummyElement")
 
 const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
 
-const EbmlSemanticContext &EbmlDummy::Context() const
-{
-  return Context_EbmlDummy;
-}
-
 } // namespace libebml


### PR DESCRIPTION
We can use ClassInfo directly now. We can also remove the virtual of some methods.