### PR TITLE
[RFC] keep track of minver and maxver per element

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -278,9 +278,32 @@ class EBML_DLL_API EbmlDocVersion {
       , maxver(max)
     {}
 
+    // the element with this EbmlDocVersion should never be used if this methods return true
+    bool IsAlwaysDeprecated() const {
+      return minver == ANY_VERSION;
+    }
+
+    // return true if the element with this EbmlDocVersion can be used with the given doctype_version
+    bool IsValidInVersion(version_type doctype_version) const {
+      if (minver == ANY_VERSION)
+        return false;
+      if (doctype_version < minver)
+        return false;
+      return doctype_version <= maxver;
+    }
+
+    // the minimum DocType version the element with this EbmlDocVersion is allowed in,
+    // ANY_VERSION if the element is never supported
+    version_type GetMinVersion() const { return minver; }
+
+    // the maximum DocType version the element with this EbmlDocVersion is allowed in,
+    // ANY_VERSION if the element is supported in all (known) version
+    version_type GetMaxVersion() const { return maxver; }
+
     /// @brief constant value to indicate the maximum version matches all versions or the minimum version matches no version
     static const version_type ANY_VERSION = std::numeric_limits<version_type>::max();
 
+  private:
     // the minimum DocType version this element is allowed in
     // ANY_VERSION if the element is never supported
     const version_type minver;

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -55,93 +55,94 @@ class EbmlElement;
 #define DEFINE_xxx_CONTEXT(x,global) \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
-#define DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,global) \
+#define DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,versions,global) \
     constexpr const libebml::EbmlId Id_##x    (id, idl); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x); \
+    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
     x::x() :libebml::EbmlMaster(x::ClassInfos, Context_##x) {}
 
 // define a master class with a custom constructor
-#define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,infinite,name,global) \
+#define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,infinite,name,versions,global) \
     constexpr const libebml::EbmlId Id_##x    (id, idl); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x);
+    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions);
 
 // define a master class with no parent class
-#define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,infinite,name,global) \
+#define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,infinite,name,versions,global) \
     constexpr const libebml::EbmlId Id_##x    (id, idl); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
-    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x); \
+    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
     constexpr const libebml::EbmlId Id_##x    (id, idl); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x));
 
-#define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,idl,parent,name,global) \
+#define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,idl,parent,name,versions,global) \
     DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
-    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x); \
+    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x, versions); \
     x::x() :libebml::BaseClass(x::ClassInfos) {}
 
-#define DEFINE_xxx_CLASS_BASE_DEFAULT(x,BaseClass,id,idl,parent,name,global,StorageType,defval) \
+#define DEFINE_xxx_CLASS_BASE_DEFAULT(x,BaseClass,id,idl,parent,name,global,StorageType,defval,versions) \
     DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
-    const libebml::EbmlCallbacksWithDefault<StorageType> x::ClassInfos(x::Create, Id_##x, defval, name, Context_##x); \
+    const libebml::EbmlCallbacksWithDefault<StorageType> x::ClassInfos(x::Create, Id_##x, defval, name, Context_##x, versions); \
     x::x() :libebml::BaseClass(x::ClassInfos) {}
 
-#define DEFINE_xxx_CLASS_BASE_NODEFAULT(x,BaseClass,id,idl,parent,name,global,StorageType) \
+#define DEFINE_xxx_CLASS_BASE_NODEFAULT(x,BaseClass,id,idl,parent,name,global,StorageType,versions) \
     DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
-    const libebml::EbmlCallbacksDefault<StorageType> x::ClassInfos(x::Create, Id_##x, name, Context_##x); \
+    const libebml::EbmlCallbacksDefault<StorageType> x::ClassInfos(x::Create, Id_##x, name, Context_##x, versions); \
     x::x() :libebml::BaseClass(x::ClassInfos) {}
 
-#define DEFINE_xxx_UINTEGER(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUInteger,id,idl,parent,name,global,std::uint64_t)
+#define DEFINE_xxx_UINTEGER(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUInteger,id,idl,parent,name,global,std::uint64_t,versions)
 
-#define DEFINE_xxx_SINTEGER(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlSInteger,id,idl,parent,name,global,std::int64_t)
+#define DEFINE_xxx_SINTEGER(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlSInteger,id,idl,parent,name,global,std::int64_t,versions)
 
-#define DEFINE_xxx_STRING(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlString,id,idl,parent,name,global,const char *)
+#define DEFINE_xxx_STRING(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlString,id,idl,parent,name,global,const char *,versions)
 
-#define DEFINE_xxx_UNISTRING(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUnicodeString,id,idl,parent,name,global, const wchar_t *)
+#define DEFINE_xxx_UNISTRING(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUnicodeString,id,idl,parent,name,global, const wchar_t *,versions)
 
-#define DEFINE_xxx_FLOAT(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlFloat,id,idl,parent,name,global,double)
+#define DEFINE_xxx_FLOAT(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlFloat,id,idl,parent,name,global,double,versions)
 
-#define DEFINE_xxx_DATE(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlDate,id,idl,parent,name,global,std::int64_t)
+#define DEFINE_xxx_DATE(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlDate,id,idl,parent,name,global,std::int64_t,versions)
 
-#define DEFINE_xxx_BINARY(x,id,idl,parent,name,global) \
-    DEFINE_xxx_CLASS_BASE(x,EbmlBinary,id,idl,parent,name,global)
+#define DEFINE_xxx_BINARY(x,id,idl,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE(x,EbmlBinary,id,idl,parent,name,versions,global)
 
-#define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUInteger,id,idl,parent,name,global,std::uint64_t,defval)
+#define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUInteger,id,idl,parent,name,global,std::uint64_t,defval, versions)
 
-#define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlSInteger,id,idl,parent,name,global,std::int64_t,defval)
+#define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlSInteger,id,idl,parent,name,global,std::int64_t,defval, versions)
 
-#define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlString,id,idl,parent,name,global,const char *,defval)
+#define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlString,id,idl,parent,name,global,const char *,defval, versions)
 
-#define DEFINE_xxx_UNISTRING_DEF(x,id,idl,parent,name,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUnicodeString,id,idl,parent,name,global,const wchar_t*,defval)
+#define DEFINE_xxx_UNISTRING_DEF(x,id,idl,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUnicodeString,id,idl,parent,name,global,const wchar_t*,defval, versions)
 
-#define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlFloat,id,idl,parent,name,global,double,defval)
+#define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlFloat,id,idl,parent,name,global,double,defval, versions)
 
-#define DEFINE_xxx_DATE_DEF(x,id,idl,parent,name,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,idl,parent,name,global,defval)
+#define DEFINE_xxx_DATE_DEF(x,id,idl,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,idl,parent,name,versions,global,defval, versions)
 
-#define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,global) \
+#define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,versions,global) \
     constexpr const libebml::EbmlId Id_##x    (id, idl); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
-    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x); \
+    const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x, versions); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,GetEbmlGlobal_Context)
-#define DEFINE_EBML_MASTER(x,id,idl,parent,infinite,name)  DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,GetEbmlGlobal_Context)
-#define DEFINE_EBML_MASTER_ORPHAN(x,id,idl,infinite,name)  DEFINE_xxx_MASTER_ORPHAN(x,id,idl,infinite,name,GetEbmlGlobal_Context)
-#define DEFINE_EBML_CLASS_ORPHAN(x,id,idl,name)            DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,GetEbmlGlobal_Context)
-#define DEFINE_EBML_UINTEGER_DEF(x,id,idl,parent,name,val) DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,GetEbmlGlobal_Context,val)
-#define DEFINE_EBML_STRING_DEF(x,id,idl,parent,name,val)   DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,GetEbmlGlobal_Context,val)
+
+#define DEFINE_EBML_MASTER(x,id,idl,parent,infinite,name,versions)  DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,versions,GetEbmlGlobal_Context)
+#define DEFINE_EBML_MASTER_ORPHAN(x,id,idl,infinite,name,versions)  DEFINE_xxx_MASTER_ORPHAN(x,id,idl,infinite,name,versions,GetEbmlGlobal_Context)
+#define DEFINE_EBML_CLASS_ORPHAN(x,id,idl,name,versions)            DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,versions,GetEbmlGlobal_Context)
+#define DEFINE_EBML_UINTEGER_DEF(x,id,idl,parent,name,val,versions) DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,versions,GetEbmlGlobal_Context,val)
+#define DEFINE_EBML_STRING_DEF(x,id,idl,parent,name,val,versions)   DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,versions,GetEbmlGlobal_Context,val)
 
 #define DEFINE_SEMANTIC_CONTEXT(x)
 #define DEFINE_START_SEMANTIC(x)     static const libebml::EbmlSemantic ContextList_##x[] = {
@@ -295,7 +296,7 @@ class EBML_DLL_API EbmlDocVersion {
 class EBML_DLL_API EbmlCallbacks {
   public:
     constexpr EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, bool aCanInfinite, const char * aDebugName, const EbmlSemanticContext & aContext,
-                            const EbmlDocVersion & aVersion = {})
+                            const EbmlDocVersion & aVersion)
       :Create(Creator)
       ,GlobalId(aGlobalId)
       ,CanInfinite(aCanInfinite)
@@ -331,7 +332,7 @@ template<typename T>
 class EBML_DLL_API EbmlCallbacksDefault : public EbmlCallbacks {
   public:
     constexpr EbmlCallbacksDefault(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, const char * aDebugName, const EbmlSemanticContext & aContext,
-                                   const EbmlDocVersion & aVersion = {})
+                                   const EbmlDocVersion & aVersion)
       :EbmlCallbacks(Creator, aGlobalId, false, aDebugName, aContext, aVersion)
     {
     }
@@ -343,7 +344,7 @@ template<typename T>
 class EBML_DLL_API EbmlCallbacksWithDefault : public EbmlCallbacksDefault<T> {
   public:
     constexpr EbmlCallbacksWithDefault(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, const T &def, const char * aDebugName, const EbmlSemanticContext & aContext,
-                                       const EbmlDocVersion & aVersion = {})
+                                       const EbmlDocVersion & aVersion)
       :EbmlCallbacksDefault<T>(Creator, aGlobalId, aDebugName, aContext, aVersion)
       ,defaultValue(def)
     {

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -7,7 +7,6 @@
   \author Julien Coloos  <suiryc @ users.sf.net>
 */
 #include <cassert>
-#include <limits>
 #include <string>
 
 #include "ebml/EbmlBinary.h"

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -26,7 +26,7 @@ static constexpr std::uint32_t CRC32_NEGL = 0xffffffffL;
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, 1, "EBMLCrc32\0ratamadabapa")
+DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, 1, "EBMLCrc32\0ratamadabapa", EbmlDocVersion{})
 
 static constexpr std::array<std::uint32_t, 256> s_tab {
 #ifdef WORDS_BIGENDIAN

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -12,7 +12,6 @@
 #include "ebml/MemIOCallback.h"
 
 #include <array>
-#include <limits>
 #include <memory>
 
 #ifdef WORDS_BIGENDIAN

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, 1, "DummyElement")
+DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, 1, "DummyElement", EbmlDocVersion{} )
 
 const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
 

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -10,13 +10,13 @@
 
 namespace libebml {
 
-DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, 2, EbmlHead, "EBMLVersion", 1)
-DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, 2, EbmlHead, "EBMLReadVersion", 1)
-DEFINE_EBML_UINTEGER_DEF(EMaxIdLength,        0x42F2, 2, EbmlHead, "EBMLMaxIdLength", 4)
-DEFINE_EBML_UINTEGER_DEF(EMaxSizeLength,      0x42F3, 2, EbmlHead, "EBMLMaxSizeLength", 8)
-DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, 2, EbmlHead, "EBMLDocType", "matroska")
-DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, 2, EbmlHead, "EBMLDocTypeVersion", 1)
-DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, 2, EbmlHead, "EBMLDocTypeReadVersion", 1)
+DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, 2, EbmlHead, "EBMLVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, 2, EbmlHead, "EBMLReadVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EMaxIdLength,        0x42F2, 2, EbmlHead, "EBMLMaxIdLength", 4, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EMaxSizeLength,      0x42F3, 2, EbmlHead, "EBMLMaxSizeLength", 8, EbmlDocVersion{})
+DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, 2, EbmlHead, "EBMLDocType", "matroska", EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, 2, EbmlHead, "EBMLDocTypeVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, 2, EbmlHead, "EBMLDocTypeReadVersion", 1, EbmlDocVersion{})
 
 DEFINE_START_SEMANTIC(EbmlHead)
 DEFINE_SEMANTIC_ITEM(true, true, EVersion)        ///< EBMLVersion
@@ -28,7 +28,7 @@ DEFINE_SEMANTIC_ITEM(true, true, EDocTypeVersion) ///< DocTypeVersion
 DEFINE_SEMANTIC_ITEM(true, true, EDocTypeReadVersion) ///< DocTypeReadVersion
 DEFINE_END_SEMANTIC(EbmlHead)
 
-DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, 4, false, "EBMLHead\0ratamapaga")
+DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, 4, false, "EBMLHead\0ratamapaga", EbmlDocVersion{})
 
 EbmlHead::EbmlHead()
   :EbmlMaster(EbmlHead::ClassInfos, Context_EbmlHead)

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -8,7 +8,6 @@
 
 #include <cassert>
 #include <algorithm>
-#include <limits>
 
 #include "ebml/EbmlMaster.h"
 #include "ebml/EbmlStream.h"

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -8,7 +8,6 @@
 */
 #include <array>
 #include <cassert>
-#include <limits>
 #include <cstdint>
 
 #include "ebml/EbmlSInteger.h"

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -6,7 +6,6 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 #include <cassert>
-#include <limits>
 
 #include "ebml/EbmlString.h"
 

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -9,7 +9,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <limits>
 
 #include "ebml/EbmlUnicodeString.h"
 

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, 1, "EBMLVoid")
+DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, 1, "EBMLVoid", EbmlDocVersion{})
 
 EbmlVoid::EbmlVoid()
   :EbmlBinary(EbmlVoid::ClassInfos)

--- a/test/test_infinite.cxx
+++ b/test/test_infinite.cxx
@@ -27,10 +27,10 @@ DECLARE_xxx_MASTER(NoInfinite,)
 EBML_CONCRETE_CLASS(NoInfinite)
 };
 
-DEFINE_EBML_MASTER_ORPHAN(CanInfinite, 0xF0, 1, true, "CanInfinite")
-DEFINE_EBML_MASTER_ORPHAN(NoInfinite, 0xF0, 1, false, "NoInfinite")
+DEFINE_EBML_MASTER_ORPHAN(CanInfinite, 0xF0, 1, true, "CanInfinite", EbmlDocVersion{})
+DEFINE_EBML_MASTER_ORPHAN(NoInfinite, 0xF0, 1, false, "NoInfinite", EbmlDocVersion{})
 
-DEFINE_EBML_UINTEGER_DEF(DummyChild, 0x42F7, 2, CanInfinite, "DummyChild", 0)
+DEFINE_EBML_UINTEGER_DEF(DummyChild, 0x42F7, 2, CanInfinite, "DummyChild", 0, EbmlDocVersion{})
 
 CanInfinite::CanInfinite()
     :EbmlMaster(CanInfinite::ClassInfos, Context_CanInfinite)

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -8,32 +8,32 @@ using namespace libebml;
 DECLARE_EBML_STRING_DEF(StringWithDefault)
     EBML_CONCRETE_CLASS(StringWithDefault)
 };
-DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, 2, EbmlHead, "StringWithDefault", "Default Value")
+DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, 2, EbmlHead, "StringWithDefault", "Default Value", EbmlDocVersion{})
 
 DECLARE_xxx_STRING(StringWithoutDefault,)
     EBML_CONCRETE_CLASS(StringWithoutDefault)
 };
-DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, 2, EbmlHead, "StringWithoutDefault", GetEbmlGlobal_Context)
+DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, 2, EbmlHead, "StringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
 
 DECLARE_xxx_UNISTRING_DEF(UniStringWithDefault,)
     EBML_CONCRETE_CLASS(UniStringWithDefault)
 };
-DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, 2, EbmlHead, "UniStringWithDefault", GetEbmlGlobal_Context, L"Default Value")
+DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, 2, EbmlHead, "UniStringWithDefault", EbmlDocVersion{}, GetEbmlGlobal_Context, L"Default Value")
 
 DECLARE_xxx_UNISTRING(UniStringWithoutDefault,)
     EBML_CONCRETE_CLASS(UniStringWithoutDefault)
 };
-DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, 2, EbmlHead, "UniStringWithoutDefault", GetEbmlGlobal_Context)
+DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, 2, EbmlHead, "UniStringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
 
 DECLARE_EBML_UINTEGER_DEF(UIntWithDefault)
     EBML_CONCRETE_CLASS(UIntWithDefault)
 };
-DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, 3, EbmlHead, "UIntWithDefault", 42)
+DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, 3, EbmlHead, "UIntWithDefault", 42, EbmlDocVersion{})
 
 DECLARE_xxx_UINTEGER(UIntWithoutDefault,)
     EBML_CONCRETE_CLASS(UIntWithoutDefault)
 };
-DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, 3, EbmlHead, "UIntWithoutDefault", GetEbmlGlobal_Context)
+DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, 3, EbmlHead, "UIntWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
 
 int main(void)
 {


### PR DESCRIPTION
They correspond to the attributes in the EBML specs.

For they are just informational. We may use this information when reading data to find which element are allowed given the read/version in the EBML header, that can help with error recovery, skipping elements that are not legit given the context.