### PR TITLE
Don't attempt to write deprecated elements

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -454,11 +454,12 @@ class EBML_DLL_API EbmlElement {
     static bool WriteSkipDefault(const EbmlElement &elt) {
       if (elt.IsDefaultValue())
         return false;
-      return true;
+      return !elt.ElementSpec().GetVersions().IsAlwaysDeprecated();
     }
 
-    static bool WriteAll(const EbmlElement &) {
-      return true;
+    // write all elements except deprecated ones
+    static bool WriteAll(const EbmlElement & elt) {
+      return !elt.ElementSpec().GetVersions().IsAlwaysDeprecated();
     }
 
     explicit EbmlElement(const EbmlCallbacks &, std::uint64_t aDefaultSize, bool bValueSet = false);


### PR DESCRIPTION
On top of https://github.com/Matroska-Org/libebml/pull/207 only the last commit "don't try to write elements that are deprecated" matters here.

The write filter allows to skip gracefully the elements that should never be written. Such elements are currently asserting in RenderData and return 0 there. This would likely break the internals as the written size no longer matches the UpdateSize value. Relying on the write filter fixes this as the same element will be skipped in UpdateSize and in Render(Data).

Eventually it would be nice to remove the RenderData overrides and just rely on this. However whoever implements a custom write filter (mkvtoolnix) should probably take this in consideration. If we remove the overrides we will allow writing deprecated elements in some circumstances, which is currently not possible.

The same system allows filtering out different level of min/max for a given render call.