### PR TITLE
factorize the calls to the write filter per element

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -509,6 +509,10 @@ class EBML_DLL_API EbmlElement {
       return SizePosition + CodedSizeLength(Size, SizeLength, bSizeIsFinite) + Size;
     }
 
+    virtual bool CanWrite(ShouldWrite & writeFilter) const {
+      return writeFilter(*this);
+    }
+
   protected:
     /*!
       \brief find any element in the stream

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -477,9 +477,9 @@ EbmlElement *EbmlElement::CreateElementUsingContext(const EbmlId & aID, const Eb
 */
 filepos_t EbmlElement::Render(IOCallback & output, ShouldWrite writeFilter, bool bKeepPosition, bool bForceRender)
 {
-  assert(bValueIsSet || writeFilter(*this)); // an element is been rendered without a value set !!!
+  assert(bValueIsSet || CanWrite(writeFilter)); // an element is been rendered without a value set !!!
   // it may be a mandatory element without a default value
-  if (!writeFilter(*this)) {
+  if (!CanWrite(writeFilter)) {
     return 0;
   }
 #if !defined(NDEBUG)
@@ -533,7 +533,7 @@ filepos_t EbmlElement::MakeRenderHead(IOCallback & output, bool bKeepPosition)
 
 std::uint64_t EbmlElement::ElementSize(ShouldWrite writeFilter) const
 {
-  if (!writeFilter(*this))
+  if (!CanWrite(writeFilter))
     return 0; // won't be saved
   return Size + EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
 }

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -55,7 +55,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, Sh
 
 std::uint64_t EbmlFloat::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!writeFilter(*this))
+  if (!CanWrite(writeFilter))
     return 0;
   return GetSize();
 }

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -59,14 +59,14 @@ filepos_t EbmlMaster::RenderData(IOCallback & output, bool bForceRender, ShouldW
 
   if (!bChecksumUsed) { // old school
     for (auto Element : ElementList) {
-      if (!writeFilter(*Element))
+      if (!Element->CanWrite(writeFilter))
         continue;
       Result += Element->Render(output, writeFilter, false ,bForceRender);
     }
   } else { // new school
     MemIOCallback TmpBuf(GetSize() - 6);
     for (auto Element : ElementList) {
-      if (!writeFilter(*Element))
+      if (!Element->CanWrite(writeFilter))
         continue;
       Element->Render(TmpBuf, writeFilter, false ,bForceRender);
     }
@@ -107,7 +107,7 @@ std::uint64_t EbmlMaster::UpdateSize(ShouldWrite writeFilter, bool bForceRender)
     }
 
   for (auto Element : ElementList) {
-    if (!writeFilter(*Element))
+    if (!Element->CanWrite(writeFilter))
       continue;
     Element->UpdateSize(writeFilter, bForceRender);
     const std::uint64_t SizeToAdd = Element->ElementSize(writeFilter);

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -70,7 +70,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
 
 std::uint64_t EbmlSInteger::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!writeFilter(*this))
+  if (!CanWrite(writeFilter))
     return 0;
 
   const auto Value = GetValue();

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -43,7 +43,7 @@ filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, S
 
 std::uint64_t EbmlString::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!writeFilter(*this))
+  if (!CanWrite(writeFilter))
     return 0;
 
   if (Value.length() < GetDefaultSize()) {

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -51,7 +51,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
 
 std::uint64_t EbmlUInteger::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!writeFilter(*this))
+  if (!CanWrite(writeFilter))
     return 0;
 
   const auto Value = GetValue();

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -147,7 +147,7 @@ std::string EbmlUnicodeString::GetValueUTF8() const {
 */
 std::uint64_t EbmlUnicodeString::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
 {
-  if (!writeFilter(*this))
+  if (!CanWrite(writeFilter))
     return 0;
 
   SetSize_(Value.GetUTF8().length());


### PR DESCRIPTION
We can add generic code in there. In particular it allows libmatroska to do extra filter that may not be welcome in the more generic libebml.