### PR TITLE
Don't allow to write deprecated elements 

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -457,6 +457,7 @@ class EBML_DLL_API EbmlElement {
       return true;
     }
 
+    // write all elements except deprecated ones
     static bool WriteAll(const EbmlElement &) {
       return true;
     }
@@ -569,6 +570,8 @@ class EBML_DLL_API EbmlElement {
     }
 
     virtual bool CanWrite(const ShouldWrite & writeFilter) const {
+      if (ElementSpec().GetVersions().IsAlwaysDeprecated())
+        return false;
       return writeFilter(*this);
     }
 


### PR DESCRIPTION
On top of #207 and #210 only the last 2 commits matter here.

Alternative version of https://github.com/Matroska-Org/libebml/pull/209 which forbids the writing of deprecated elements, rather than letting the user filter them out manually.

That limits a bit the flexibility of libebml. Given the method is virtual this can be done in libmatroska which took the decision a long time ago not to allow writing deprecated elements.

--------

Since it is stricter (than #209) and will not later any deprecated element ever be writen (unless there's a bug in the writing code) we could remove all the fake RenderData() methods for deprecated elements. They will never be called.
