### PR TITLE
Allow settling a length constraint on binary elements

### DIFF
--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -17,9 +17,8 @@
 
 namespace libebml {
 
-DECLARE_EBML_BINARY(EbmlCrc32)
+DECLARE_EBML_BINARY_LENGTH(EbmlCrc32, 4)
   public:
-    bool ValidateSize() const override {return GetSize() == 4;}
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
 //    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault);

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -184,6 +184,10 @@ class DllApi x : public BaseClass { \
 #define DECLARE_xxx_BINARY(x,DllApi)    \
   DECLARE_xxx_BASE(x, DllApi, libebml::EbmlBinary)
 
+#define DECLARE_xxx_BINARY_LENGTH(x,len,DllApi)    \
+  DECLARE_xxx_BASE(x, DllApi, libebml::EbmlBinary) \
+  bool ValidateSize() const override {return GetSize() == len;}
+
 #define DECLARE_xxx_UINTEGER(x,DllApi)  \
   DECLARE_xxx_BASE_NODEFAULT(x, DllApi, libebml::EbmlUInteger, std::uint64_t)
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -228,6 +228,7 @@ class DllApi x : public BaseClass { \
 #define DECLARE_EBML_UINTEGER_DEF(x)  DECLARE_xxx_UINTEGER_DEF(x,EBML_DLL_API)
 #define DECLARE_EBML_STRING_DEF(x)    DECLARE_xxx_STRING_DEF(  x,EBML_DLL_API)
 #define DECLARE_EBML_BINARY(x)    DECLARE_xxx_BINARY(  x,EBML_DLL_API)
+#define DECLARE_EBML_BINARY_LENGTH(x,len)    DECLARE_xxx_BINARY_LENGTH(x,len,EBML_DLL_API)
 
 #define EBML_CONCRETE_CLASS(Type) \
     public: \


### PR DESCRIPTION
With a template we may only have one macro with a default value for the length...