### PR TITLE
Create less bogus elements on reading

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -515,7 +515,9 @@ class EBML_DLL_API EbmlElement {
       \brief find any element in the stream
       \return a DummyRawElement if the element is unknown or nullptr if the element dummy is not allowed
     */
-    static EbmlElement *CreateElementUsingContext(const EbmlId & aID, const EbmlSemanticContext & Context, int & LowLevel, bool IsGlobalContext, bool bAllowDummy = false, unsigned int MaxLowerLevel = 1);
+    static EbmlElement *CreateElementUsingContext(const EbmlId & aID, const EbmlSemanticContext & Context, int & LowLevel, bool IsGlobalContext,
+                                                  bool AsInfiniteSize,
+                                                  bool bAllowDummy = false, unsigned int MaxLowerLevel = 1);
 
     filepos_t RenderHead(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault, bool bKeepPosition = false);
     filepos_t MakeRenderHead(IOCallback & output, bool bKeepPosition);

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -219,14 +219,14 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
   if (Result == nullptr)
     return nullptr;
 
-  Result->SetSizeLength(PossibleSizeLength);
-
-  Result->Size = SizeFound;
-
   if (!Result->ValidateSize()) {
     delete Result;
     return nullptr;
   }
+
+  Result->SetSizeLength(PossibleSizeLength);
+
+  Result->Size = SizeFound;
 
   Result->SetSizeInfinite(SizeFound == SizeUnknown);
   Result->ElementPosition = aElementPosition;

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -142,7 +142,6 @@ EbmlElement::EbmlElement(const EbmlCallbacks & classInfo, std::uint64_t aDefault
 }
 
 /*!
-  \todo this method is deprecated and should be called FindThisID
   \todo replace the new RawElement with the appropriate class (when known)
 */
 EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize)


### PR DESCRIPTION
If the size is invalid, we will return nullptr. So let's not create the element in the first place.

The first patch can be backported to 1.x