### PR TITLE
use a default initializer for the EbmlMaster checksum boolean

### DIFF
--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -22,7 +22,7 @@
 
 namespace libebml {
 
-const bool bChecksumUsedByDefault = false;
+constexpr const bool bChecksumUsedByDefault = false;
 
 /*!
     \class EbmlMaster
@@ -150,7 +150,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
 
     const EbmlSemanticContext & MasterContext;
 
-    bool      bChecksumUsed;
+    bool      bChecksumUsed = bChecksumUsedByDefault;
     EbmlCrc32 Checksum;
 
   private:

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -18,7 +18,7 @@
 namespace libebml {
 
 EbmlMaster::EbmlMaster(const EbmlCallbacks & classInfo, const EbmlSemanticContext & aContext, bool bSizeIsknown)
- :EbmlElement(classInfo, 0), MasterContext(aContext), bChecksumUsed(bChecksumUsedByDefault)
+ :EbmlElement(classInfo, 0), MasterContext(aContext)
 {
   SetSizeInfinite(!bSizeIsknown);
   SetValueIsSet();


### PR DESCRIPTION
It's off by default. Not sure we want to keep the constexpr variable.