### PR TITLE
Pass the size to check on an element

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -30,7 +30,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
     EbmlBinary& operator=(const EbmlBinary & ElementToClone);
     ~EbmlBinary() override;
 
-    bool ValidateSize() const override {return GetSize() < 0x7FFFFFFF;} // we don't mind about what's inside
+    bool SizeIsValid(std::uint64_t size) const override {return size < 0x7FFFFFFF;} // we don't mind about what's inside
 
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -41,7 +41,7 @@ class EBML_DLL_API EbmlDate : public EbmlElementDefaultSameStorage<std::int64_t>
     std::int64_t GetEpochDate() const {return EbmlToEpoch(EbmlElementDefaultSameStorage<std::int64_t>::GetValue());}
     std::int64_t GetValue() const {return GetEpochDate();}
 
-    bool ValidateSize() const override {return GetSize() == 8 || GetSize() == 0;}
+    bool SizeIsValid(std::uint64_t size) const override {return size == 8 || size == 0;}
 
     /*!
       \note no Default date handled

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -186,7 +186,7 @@ class DllApi x : public BaseClass { \
 
 #define DECLARE_xxx_BINARY_LENGTH(x,len,DllApi)    \
   DECLARE_xxx_BASE(x, DllApi, libebml::EbmlBinary) \
-  bool ValidateSize() const override {return GetSize() == len;}
+  bool SizeIsValid(std::uint64_t size) const override {return size == len;}
 
 #define DECLARE_xxx_UINTEGER(x,DllApi)  \
   DECLARE_xxx_BASE_NODEFAULT(x, DllApi, libebml::EbmlUInteger, std::uint64_t)
@@ -453,7 +453,8 @@ class EBML_DLL_API EbmlElement {
         return false;
     }
 
-    virtual bool ValidateSize() const = 0;
+    virtual bool SizeIsValid(std::uint64_t) const = 0;
+    bool ValidateSize() const { return SizeIsValid(GetSize()); }
 
     std::uint64_t GetElementPosition() const {
       return ElementPosition;

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -25,9 +25,9 @@ class EBML_DLL_API EbmlFloat : public EbmlElementDefaultSameStorage<double> {
 
     EbmlFloat(const EbmlCallbacksDefault<double> &, Precision prec = FLOAT_32);
 
-    bool ValidateSize() const override
+    bool SizeIsValid(std::uint64_t size) const override
     {
-      return (GetSize() == 4 || GetSize() == 8);
+      return (size == 4 || size == 8);
     }
 
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -31,7 +31,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     explicit EbmlMaster(const EbmlCallbacks &, const EbmlSemanticContext & aContext, bool bSizeIsKnown = true);
     EbmlMaster(const EbmlMaster & ElementToClone);
     EbmlMaster& operator=(const EbmlMaster&) = delete;
-    bool ValidateSize() const override {return true;}
+    bool SizeIsValid(std::uint64_t /*size*/) const override {return true;}
     /*!
       \warning be carefull to clear the memory allocated in the ElementList elsewhere
     */

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -31,7 +31,7 @@ class EBML_DLL_API EbmlSInteger : public EbmlElementDefaultSameStorage<std::int6
     */
         void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_INT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
-    bool ValidateSize() const override {return GetSize() <= 8;}
+    bool SizeIsValid(std::uint64_t size) const override {return size <= 8;}
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -22,7 +22,7 @@ class EBML_DLL_API EbmlString : public EbmlElementDefaultStorage<const char *, s
   public:
     EbmlString(const EbmlCallbacksDefault<const char *> &);
 
-    bool ValidateSize() const override {return GetSize() < 0x7FFFFFFF;} // any size is possible
+    bool SizeIsValid(std::uint64_t size) const override {return size < 0x7FFFFFFF;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -29,7 +29,7 @@ class EBML_DLL_API EbmlUInteger : public EbmlElementDefaultSameStorage<std::uint
     */
     void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_UINT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
-    bool ValidateSize() const override {return GetSize() <= 8;}
+    bool SizeIsValid(std::uint64_t size) const override {return size <= 8;}
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -68,7 +68,7 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElementDefaultStorage<const wc
   public:
     EbmlUnicodeString(const EbmlCallbacksDefault<const wchar_t *> &);
 
-    bool ValidateSize() const override {return true;} // any size is possible
+    bool SizeIsValid(std::uint64_t /*size*/) const override {return true;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -219,7 +219,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
   if (Result == nullptr)
     return nullptr;
 
-  if (!Result->ValidateSize()) {
+  if (!Result->SizeIsValid(SizeFound)) {
     delete Result;
     return nullptr;
   }
@@ -340,7 +340,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
           //  0 : child
           //  1 : same level
           //  + : further parent
-          if (Result->ValidateSize() && (SizeFound == SizeUnknown || UpperLevel > 0 || MaxDataSize == 0 ||
+          if (Result->SizeIsValid(SizeFound) && (SizeFound == SizeUnknown || UpperLevel > 0 || MaxDataSize == 0 ||
                                          MaxDataSize >= (IdStart + PossibleID_Length + _SizeLength + SizeFound))) {
             Result->ElementPosition = ParseStart + IdStart;
             Result->SizePosition = Result->ElementPosition + PossibleID_Length;


### PR DESCRIPTION
Rather than ValidateSize() which requires to set the value on the element first, we can check if the size is valid before doing it, or rejecting the element in that case.

~~On top of #212 and #213.~~

It might be possible to get the information from the element specs (and avoid creating an element just to delete right after), but that will be for another Pull Request.