### PR TITLE
move FindAllMissingElements functionality into a test example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ if (BUILD_TESTING)
   target_link_libraries(test_macros PUBLIC ebml)
   add_test(test_macros test_macros)
 
+  add_executable(test_missing test/test_missing.cxx)
+  target_link_libraries(test_missing PUBLIC ebml)
+  add_test(test_missing test_missing)
+
 endif(BUILD_TESTING)
 
 

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -8,7 +8,6 @@
 #ifndef LIBEBML_MASTER_H
 #define LIBEBML_MASTER_H
 
-#include <string>
 #include <vector>
 
 #include "EbmlTypes.h"
@@ -139,11 +138,6 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
       Checksum.ForceCrc32(NewChecksum);
       bChecksumUsed = true;
     }
-
-    /*!
-      \brief drill down all sub-elements, finding any missing elements
-    */
-    std::vector<std::string> FindAllMissingElements() const;
 
     private:
     std::vector<EbmlElement *> ElementList;

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -186,48 +186,6 @@ bool EbmlMaster::CheckMandatory() const
   return true;
 }
 
-std::vector<std::string> EbmlMaster::FindAllMissingElements() const
-{
-  assert(MasterContext.GetSize() != 0);
-
-  std::vector<std::string> missingElements;
-
-  for (auto childElement : ElementList) {
-    if (!childElement->ValueIsSet()) {
-      std::string missingValue;
-      missingValue = "The Child Element \"";
-      missingValue.append(EBML_NAME(childElement));
-      missingValue.append("\" of EbmlMaster \"");
-      missingValue.append(EBML_NAME(this));
-      missingValue.append("\", does not have a value set.");
-      missingElements.push_back(std::move(missingValue));
-    }
-
-    if (childElement->IsMaster()) {
-      const auto childMaster = static_cast<const EbmlMaster*>(childElement);
-
-      std::vector<std::string> childMissingElements = childMaster->FindAllMissingElements();
-      std::copy(childMissingElements.begin(), childMissingElements.end(), std::back_inserter(missingElements));
-    }
-  }
-  unsigned int EltIdx;
-  for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
-    if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {
-      if (FindElt(EBML_CTX_IDX_INFO(MasterContext,EltIdx)) == nullptr) {
-        std::string missingElement;
-        missingElement = "Missing element \"";
-        missingElement.append(EBML_INFO_NAME(EBML_CTX_IDX_INFO(MasterContext,EltIdx)));
-        missingElement.append("\" in EbmlMaster \"");
-        missingElement.append(EBML_INFO_NAME(*EBML_CTX_MASTER(MasterContext)));
-        missingElement.append("\"");
-        missingElements.push_back(std::move(missingElement));
-      }
-    }
-  }
-
-  return missingElements;
-}
-
 EbmlElement *EbmlMaster::FindElt(const EbmlCallbacks & Callbacks) const
 {
   auto it = std::find_if(ElementList.begin(), ElementList.end(), [&](const EbmlElement *Element)

--- a/test/test_missing.cxx
+++ b/test/test_missing.cxx
@@ -1,0 +1,59 @@
+// Copyright © 2023 Steve Lhomme.
+// SPDX-License-Identifier: ISC
+
+#include <ebml/EbmlHead.h>
+
+#include <cassert>
+#include <string>
+
+using namespace libebml;
+
+static void FindAllMissingElements(const EbmlMaster *pThis, std::vector<std::string> & missingElements)
+{
+  const EbmlSemanticContext & MasterContext = EBML_CONTEXT(pThis);
+  for (auto childElement : pThis->GetElementList()) {
+    if (!childElement->ValueIsSet()) {
+      std::string missingValue;
+      missingValue = "The Child Element \"";
+      missingValue.append(EBML_NAME(childElement));
+      missingValue.append("\" of EbmlMaster \"");
+      missingValue.append(EBML_NAME(pThis));
+      missingValue.append("\", does not have a value set.");
+      missingElements.push_back(std::move(missingValue));
+    }
+
+    if (childElement->IsMaster()) {
+      const auto childMaster = static_cast<const EbmlMaster*>(childElement);
+
+      FindAllMissingElements(childMaster, missingElements);
+    }
+  }
+  unsigned int EltIdx;
+  for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
+    if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {
+      if (pThis->FindElt(EBML_CTX_IDX_INFO(MasterContext,EltIdx)) == nullptr) {
+        std::string missingElement;
+        missingElement = "Missing element \"";
+        missingElement.append(EBML_INFO_NAME(EBML_CTX_IDX_INFO(MasterContext,EltIdx)));
+        missingElement.append("\" in EbmlMaster \"");
+        missingElement.append(EBML_INFO_NAME(*EBML_CTX_MASTER(MasterContext)));
+        missingElement.append("\"");
+        missingElements.push_back(std::move(missingElement));
+      }
+    }
+  }
+
+}
+
+int main(void)
+{
+    EbmlHead TestHead;
+    const EbmlSemanticContext & MasterContext = EBML_CONTEXT(&TestHead);
+
+    assert(MasterContext.GetSize() != 0);
+
+    std::vector<std::string> missingElements;
+    FindAllMissingElements(&TestHead, missingElements);
+
+    return 0;
+}


### PR DESCRIPTION
It's not used by anyone and is not a core functionality of libebml. It can be done externally as the test shows.