### PR TITLE
Keep the usage of temporary EbmlDocVersion instances to init global semantic classes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ if (BUILD_TESTING)
   target_link_libraries(test_missing PUBLIC ebml)
   add_test(test_missing test_missing)
 
+  add_executable(test_versioning test/test_versioning.cxx)
+  target_link_libraries(test_versioning PUBLIC ebml)
+  add_test(test_versioning test_versioning)
+
 endif(BUILD_TESTING)
 
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -161,7 +161,7 @@ class DllApi x : public BaseClass { \
     static const libebml::EbmlCallbacksWithDefault<StorageType> ClassInfos; \
   public: \
     const libebml::EbmlCallbacksWithDefault<StorageType> & ElementSpec() const override { return ClassInfos; } \
-    static const libebml::EbmlCallbacksWithDefault<StorageType> & GetElementSpec() { return ClassInfos; } \
+    static constexpr const libebml::EbmlCallbacksWithDefault<StorageType> & GetElementSpec() { return ClassInfos; } \
     x();
 
 #define DECLARE_xxx_BASE_NODEFAULT(x, DllApi, BaseClass, StorageType) \
@@ -170,7 +170,7 @@ class DllApi x : public BaseClass { \
     static const libebml::EbmlCallbacksDefault<StorageType> ClassInfos; \
   public: \
     const libebml::EbmlCallbacksDefault<StorageType> & ElementSpec() const override { return ClassInfos; } \
-    static const libebml::EbmlCallbacksDefault<StorageType> & GetElementSpec() { return ClassInfos; } \
+    static constexpr const libebml::EbmlCallbacksDefault<StorageType> & GetElementSpec() { return ClassInfos; } \
     x();
 
 #define DECLARE_xxx_BASE(x, DllApi, BaseClass) \

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -56,25 +56,25 @@ class EbmlElement;
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
+    static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
     x::x() :libebml::EbmlMaster(x::ClassInfos) {}
 
 // define a master class with a custom constructor
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
+    static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions);
 
 // define a master class with no parent class
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
+    static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
+    static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x));
 
 #define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,parent,name,versions,global) \
@@ -132,7 +132,7 @@ class EbmlElement;
     DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,parent,name,versions,global,defval, versions)
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
+    static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x, versions); \
 

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -26,7 +26,9 @@ static constexpr std::uint32_t CRC32_NEGL = 0xffffffffL;
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, "EBMLCrc32\0ratamadabapa", EbmlDocVersion{})
+static constexpr EbmlDocVersion AllEbmlVersions{};
+
+DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, "EBMLCrc32\0ratamadabapa", AllEbmlVersions)
 
 static constexpr std::array<std::uint32_t, 256> s_tab {
 #ifdef WORDS_BIGENDIAN

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -10,7 +10,9 @@
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", EbmlDocVersion{} )
+static constexpr EbmlDocVersion AllEbmlVersions{};
+
+DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", AllEbmlVersions )
 
 const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
 

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -10,13 +10,15 @@
 
 namespace libebml {
 
-DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, EbmlHead, "EBMLVersion", 1, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, EbmlHead, "EBMLReadVersion", 1, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EMaxIdLength,        0x42F2, EbmlHead, "EBMLMaxIdLength", 4, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EMaxSizeLength,      0x42F3, EbmlHead, "EBMLMaxSizeLength", 8, EbmlDocVersion{})
-DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, EbmlHead, "EBMLDocType", "matroska", EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, EbmlHead, "EBMLDocTypeVersion", 1, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, EbmlHead, "EBMLDocTypeReadVersion", 1, EbmlDocVersion{})
+static constexpr EbmlDocVersion AllEbmlVersions{};
+
+DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, EbmlHead, "EBMLVersion", 1, AllEbmlVersions)
+DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, EbmlHead, "EBMLReadVersion", 1, AllEbmlVersions)
+DEFINE_EBML_UINTEGER_DEF(EMaxIdLength,        0x42F2, EbmlHead, "EBMLMaxIdLength", 4, AllEbmlVersions)
+DEFINE_EBML_UINTEGER_DEF(EMaxSizeLength,      0x42F3, EbmlHead, "EBMLMaxSizeLength", 8, AllEbmlVersions)
+DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, EbmlHead, "EBMLDocType", "matroska", AllEbmlVersions)
+DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, EbmlHead, "EBMLDocTypeVersion", 1, AllEbmlVersions)
+DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, EbmlHead, "EBMLDocTypeReadVersion", 1, AllEbmlVersions)
 
 DEFINE_START_SEMANTIC(EbmlHead)
 DEFINE_SEMANTIC_ITEM(true, true, EVersion)        ///< EBMLVersion
@@ -28,7 +30,7 @@ DEFINE_SEMANTIC_ITEM(true, true, EDocTypeVersion) ///< DocTypeVersion
 DEFINE_SEMANTIC_ITEM(true, true, EDocTypeReadVersion) ///< DocTypeReadVersion
 DEFINE_END_SEMANTIC(EbmlHead)
 
-DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, false, "EBMLHead\0ratamapaga", EbmlDocVersion{})
+DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, false, "EBMLHead\0ratamapaga", AllEbmlVersions)
 
 EbmlHead::EbmlHead()
   :EbmlMaster(EbmlHead::ClassInfos)

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -10,7 +10,9 @@
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, "EBMLVoid", EbmlDocVersion{})
+static constexpr EbmlDocVersion AllEbmlVersions{};
+
+DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, "EBMLVoid", AllEbmlVersions)
 
 EbmlVoid::EbmlVoid()
   :EbmlBinary(EbmlVoid::ClassInfos)

--- a/test/test_infinite.cxx
+++ b/test/test_infinite.cxx
@@ -7,6 +7,8 @@
 
 using namespace libebml;
 
+static constexpr EbmlDocVersion AllVersions{};
+
 DECLARE_xxx_UINTEGER_DEF(DummyChild,)
 EBML_CONCRETE_CLASS(DummyChild)
 };
@@ -27,10 +29,10 @@ DECLARE_xxx_MASTER(NoInfinite,)
 EBML_CONCRETE_CLASS(NoInfinite)
 };
 
-DEFINE_EBML_MASTER_ORPHAN(CanInfinite, 0xF0, true, "CanInfinite", EbmlDocVersion{})
-DEFINE_EBML_MASTER_ORPHAN(NoInfinite, 0xF0, false, "NoInfinite", EbmlDocVersion{})
+DEFINE_EBML_MASTER_ORPHAN(CanInfinite, 0xF0, true, "CanInfinite", AllVersions)
+DEFINE_EBML_MASTER_ORPHAN(NoInfinite, 0xF0, false, "NoInfinite", AllVersions)
 
-DEFINE_EBML_UINTEGER_DEF(DummyChild, 0x42F7, CanInfinite, "DummyChild", 0, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(DummyChild, 0x42F7, CanInfinite, "DummyChild", 0, AllVersions)
 
 CanInfinite::CanInfinite()
     :EbmlMaster(CanInfinite::ClassInfos)

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -5,35 +5,37 @@
 
 using namespace libebml;
 
+static constexpr EbmlDocVersion AllVersions{};
+
 DECLARE_EBML_STRING_DEF(StringWithDefault)
     EBML_CONCRETE_CLASS(StringWithDefault)
 };
-DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, EbmlHead, "StringWithDefault", "Default Value", EbmlDocVersion{})
+DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, EbmlHead, "StringWithDefault", "Default Value", AllVersions)
 
 DECLARE_xxx_STRING(StringWithoutDefault,)
     EBML_CONCRETE_CLASS(StringWithoutDefault)
 };
-DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, EbmlHead, "StringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
+DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, EbmlHead, "StringWithoutDefault", AllVersions, GetEbmlGlobal_Context)
 
 DECLARE_xxx_UNISTRING_DEF(UniStringWithDefault,)
     EBML_CONCRETE_CLASS(UniStringWithDefault)
 };
-DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, EbmlHead, "UniStringWithDefault", EbmlDocVersion{}, GetEbmlGlobal_Context, L"Default Value")
+DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, EbmlHead, "UniStringWithDefault", AllVersions, GetEbmlGlobal_Context, L"Default Value")
 
 DECLARE_xxx_UNISTRING(UniStringWithoutDefault,)
     EBML_CONCRETE_CLASS(UniStringWithoutDefault)
 };
-DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, EbmlHead, "UniStringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
+DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, EbmlHead, "UniStringWithoutDefault", AllVersions, GetEbmlGlobal_Context)
 
 DECLARE_EBML_UINTEGER_DEF(UIntWithDefault)
     EBML_CONCRETE_CLASS(UIntWithDefault)
 };
-DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, EbmlHead, "UIntWithDefault", 42, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, EbmlHead, "UIntWithDefault", 42, AllVersions)
 
 DECLARE_xxx_UINTEGER(UIntWithoutDefault,)
     EBML_CONCRETE_CLASS(UIntWithoutDefault)
 };
-DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, EbmlHead, "UIntWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
+DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, EbmlHead, "UIntWithoutDefault", AllVersions, GetEbmlGlobal_Context)
 
 int main(void)
 {

--- a/test/test_versioning.cxx
+++ b/test/test_versioning.cxx
@@ -1,0 +1,205 @@
+// Copyright © 2024 Steve Lhomme.
+// SPDX-License-Identifier: ISC
+
+#include <ebml/EbmlString.h>
+#include <ebml/EbmlHead.h>
+#include <ebml/EbmlContexts.h>
+
+using namespace libebml;
+
+static constexpr EbmlDocVersion AllVersions{};
+
+DECLARE_xxx_STRING(StringClass,)
+    EBML_CONCRETE_CLASS(StringClass)
+};
+DEFINE_xxx_STRING(StringClass, 0x4321, EbmlHead, "StringClass", AllVersions, GetEbmlGlobal_Context)
+
+
+static constexpr EbmlDocVersion Deprecated{EbmlDocVersion::ANY_VERSION};
+
+DECLARE_xxx_UINTEGER(DeprecatedClass,)
+    EBML_CONCRETE_CLASS(DeprecatedClass)
+};
+DEFINE_xxx_UINTEGER(DeprecatedClass, 0x4320, EbmlHead, "DeprecatedClass", Deprecated, GetEbmlGlobal_Context)
+
+
+static constexpr EbmlDocVersion FromThree{3};
+
+DECLARE_xxx_UINTEGER(FromThreeClass,)
+    EBML_CONCRETE_CLASS(FromThreeClass)
+};
+DEFINE_xxx_UINTEGER(FromThreeClass, 0x4323, EbmlHead, "FromThreeClass", FromThree, GetEbmlGlobal_Context)
+
+
+static constexpr EbmlDocVersion UpToTwo{0,2};
+
+DECLARE_xxx_UINTEGER(UpToTwoClass,)
+    EBML_CONCRETE_CLASS(UpToTwoClass)
+};
+DEFINE_xxx_UINTEGER(UpToTwoClass, 0x4322, EbmlHead, "UpToTwoClass", UpToTwo, GetEbmlGlobal_Context)
+
+
+class ExtraVersioning : public EbmlDocVersion
+{
+public:
+    constexpr ExtraVersioning(bool webm, version_type min = 0, version_type max = ANY_VERSION)
+        :EbmlDocVersion(min, max)
+        ,InWebM(webm)
+    {}
+
+    const bool InWebM;
+};
+
+constexpr ExtraVersioning ExtraAllVersions{true};
+
+DECLARE_xxx_STRING(ExtraStringClass,)
+    EBML_CONCRETE_CLASS(ExtraStringClass)
+};
+DEFINE_xxx_STRING(ExtraStringClass, 0x4321, EbmlHead, "ExtraStringClass", ExtraAllVersions, GetEbmlGlobal_Context)
+
+
+constexpr ExtraVersioning ExtraDeprecated{false, EbmlDocVersion::ANY_VERSION};
+
+DECLARE_xxx_UINTEGER(ExtraDeprecatedClass,)
+    EBML_CONCRETE_CLASS(ExtraDeprecatedClass)
+};
+DEFINE_xxx_UINTEGER(ExtraDeprecatedClass, 0x4320, EbmlHead, "ExtraDeprecatedClass", ExtraDeprecated, GetEbmlGlobal_Context)
+
+constexpr ExtraVersioning ExtraFromThreeVersion{true, 3};
+
+DECLARE_xxx_UINTEGER(ExtraFromThreeClass,)
+    EBML_CONCRETE_CLASS(ExtraFromThreeClass)
+};
+DEFINE_xxx_UINTEGER(ExtraFromThreeClass, 0x4323, EbmlHead, "ExtraFromThreeClass", ExtraFromThreeVersion, GetEbmlGlobal_Context)
+
+
+constexpr ExtraVersioning ExtraUpToTwoVersion{false, 0, 2};
+
+DECLARE_xxx_UINTEGER(ExtraUpToTwoClass,)
+    EBML_CONCRETE_CLASS(ExtraUpToTwoClass)
+};
+DEFINE_xxx_UINTEGER(ExtraUpToTwoClass, 0x4322, EbmlHead, "ExtraUpToTwoClass", ExtraUpToTwoVersion, GetEbmlGlobal_Context)
+
+
+int main(void)
+{
+    StringClass StringClass;
+    const auto & specAll = StringClass.ElementSpec();
+    if (!specAll.GetVersions().IsValidInVersion(1))
+        return 1;
+
+    if (specAll.GetVersions().IsAlwaysDeprecated())
+        return 1;
+
+
+    DeprecatedClass DeprecatedClass;
+    const auto & specDeprecated = DeprecatedClass.ElementSpec();
+    if (specDeprecated.GetVersions().IsValidInVersion(1))
+        return 1;
+
+    if (!specDeprecated.GetVersions().IsAlwaysDeprecated())
+        return 1;
+
+
+    FromThreeClass FromThreeClass;
+    const auto & specFromThree = FromThreeClass.ElementSpec();
+    if (specFromThree.GetVersions().IsValidInVersion(1))
+        return 1;
+
+    if (!specFromThree.GetVersions().IsValidInVersion(3))
+        return 1;
+
+    if (!specFromThree.GetVersions().IsValidInVersion(4))
+        return 1;
+
+    if (specFromThree.GetVersions().IsAlwaysDeprecated())
+        return 1;
+
+
+    const auto & specUpToTwo = UpToTwoClass::GetElementSpec();
+    if (!specUpToTwo.GetVersions().IsValidInVersion(1))
+        return 1;
+
+    if (!specUpToTwo.GetVersions().IsValidInVersion(2))
+        return 1;
+
+    if (specUpToTwo.GetVersions().IsValidInVersion(3))
+        return 1;
+
+    if (specUpToTwo.GetVersions().IsAlwaysDeprecated())
+        return 1;
+
+
+
+    ExtraStringClass ExtraStringClass;
+    const auto & specAllExtra = static_cast<const ExtraVersioning &>(ExtraStringClass.ElementSpec().GetVersions());
+    if (!specAllExtra.IsValidInVersion(1))
+        return 1;
+
+    if (specAllExtra.IsAlwaysDeprecated())
+        return 1;
+
+    if (specAllExtra.IsAlwaysDeprecated())
+        return 1;
+
+    if (!specAllExtra.InWebM)
+        return 1;
+
+
+    const auto * specDeprecatedExtra = static_cast<const ExtraVersioning *>(&ExtraDeprecatedClass::GetElementSpec().GetVersions());
+    if (specDeprecatedExtra->IsValidInVersion(1))
+        return 1;
+
+    if (!specDeprecatedExtra->IsAlwaysDeprecated())
+        return 1;
+
+    if (specDeprecatedExtra->InWebM)
+        return 1;
+
+
+    ExtraFromThreeClass ExtraFromThreeClass;
+    const auto & specFromThreeExtra = ExtraFromThreeClass.ElementSpec();
+    if (specFromThreeExtra.GetVersions().IsValidInVersion(1))
+        return 1;
+
+    if (!specFromThreeExtra.GetVersions().IsValidInVersion(3))
+        return 1;
+
+    if (!specFromThreeExtra.GetVersions().IsValidInVersion(4))
+        return 1;
+
+    if (specFromThreeExtra.GetVersions().IsAlwaysDeprecated())
+        return 1;
+
+    const ExtraVersioning * p_specFromThreeExtra = static_cast<const ExtraVersioning *>(&specFromThreeExtra.GetVersions());
+    if (p_specFromThreeExtra->IsValidInVersion(1))
+        return 1;
+
+    if (!p_specFromThreeExtra->IsValidInVersion(3))
+        return 1;
+
+    if (!p_specFromThreeExtra->IsValidInVersion(4))
+        return 1;
+
+    if (p_specFromThreeExtra->IsAlwaysDeprecated())
+        return 1;
+
+    if (!p_specFromThreeExtra->InWebM)
+        return 1;
+
+
+    const auto & specUpToTwoExtra = ExtraUpToTwoClass::GetElementSpec();
+    if (!specUpToTwoExtra.GetVersions().IsValidInVersion(1))
+        return 1;
+
+    if (!specUpToTwoExtra.GetVersions().IsValidInVersion(2))
+        return 1;
+
+    if (specUpToTwoExtra.GetVersions().IsValidInVersion(3))
+        return 1;
+
+    if (specUpToTwoExtra.GetVersions().IsAlwaysDeprecated())
+        return 1;
+
+    return 0;
+}


### PR DESCRIPTION
**This will need an update on the libmatroska side before this is merged.** After this MR it won't be possible to used temporary EbmlDocVersion anymore.
=> https://github.com/Matroska-Org/libebml/pull/228

We now have the EbmlId static+constepr and the Semantic and SemanticContext constexpr. 

A test has been added to test the various issues found with EbmlDocVersion usage.