### PR TITLE
Rework Id creation to check statically for invalid IDs

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -55,94 +55,94 @@ class EbmlElement;
 #define DEFINE_xxx_CONTEXT(x,global) \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
-#define DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    (id, idl); \
+#define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
+    constexpr const libebml::EbmlId Id_##x    {id}; \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
     x::x() :libebml::EbmlMaster(x::ClassInfos) {}
 
 // define a master class with a custom constructor
-#define DEFINE_xxx_MASTER_CONS(x,id,idl,parent,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    (id, idl); \
+#define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
+    constexpr const libebml::EbmlId Id_##x    {id}; \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions);
 
 // define a master class with no parent class
-#define DEFINE_xxx_MASTER_ORPHAN(x,id,idl,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    (id, idl); \
+#define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
+    constexpr const libebml::EbmlId Id_##x    {id}; \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
-#define DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
-    constexpr const libebml::EbmlId Id_##x    (id, idl); \
+#define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
+    constexpr const libebml::EbmlId Id_##x    {id}; \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x));
 
-#define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
+#define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x, versions); \
     x::x() :libebml::BaseClass(x::ClassInfos) {}
 
-#define DEFINE_xxx_CLASS_BASE_DEFAULT(x,BaseClass,id,idl,parent,name,global,StorageType,defval,versions) \
-    DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
+#define DEFINE_xxx_CLASS_BASE_DEFAULT(x,BaseClass,id,parent,name,global,StorageType,defval,versions) \
+    DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
     const libebml::EbmlCallbacksWithDefault<StorageType> x::ClassInfos(x::Create, Id_##x, defval, name, Context_##x, versions); \
     x::x() :libebml::BaseClass(x::ClassInfos) {}
 
-#define DEFINE_xxx_CLASS_BASE_NODEFAULT(x,BaseClass,id,idl,parent,name,global,StorageType,versions) \
-    DEFINE_xxx_CLASS_CONS(x,id,idl,parent,name,global) \
+#define DEFINE_xxx_CLASS_BASE_NODEFAULT(x,BaseClass,id,parent,name,global,StorageType,versions) \
+    DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
     const libebml::EbmlCallbacksDefault<StorageType> x::ClassInfos(x::Create, Id_##x, name, Context_##x, versions); \
     x::x() :libebml::BaseClass(x::ClassInfos) {}
 
-#define DEFINE_xxx_UINTEGER(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUInteger,id,idl,parent,name,global,std::uint64_t,versions)
+#define DEFINE_xxx_UINTEGER(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUInteger,id,parent,name,global,std::uint64_t,versions)
 
-#define DEFINE_xxx_SINTEGER(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlSInteger,id,idl,parent,name,global,std::int64_t,versions)
+#define DEFINE_xxx_SINTEGER(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlSInteger,id,parent,name,global,std::int64_t,versions)
 
-#define DEFINE_xxx_STRING(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlString,id,idl,parent,name,global,const char *,versions)
+#define DEFINE_xxx_STRING(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlString,id,parent,name,global,const char *,versions)
 
-#define DEFINE_xxx_UNISTRING(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUnicodeString,id,idl,parent,name,global, const wchar_t *,versions)
+#define DEFINE_xxx_UNISTRING(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlUnicodeString,id,parent,name,global, const wchar_t *,versions)
 
-#define DEFINE_xxx_FLOAT(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlFloat,id,idl,parent,name,global,double,versions)
+#define DEFINE_xxx_FLOAT(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlFloat,id,parent,name,global,double,versions)
 
-#define DEFINE_xxx_DATE(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlDate,id,idl,parent,name,global,std::int64_t,versions)
+#define DEFINE_xxx_DATE(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE_NODEFAULT(x,EbmlDate,id,parent,name,global,std::int64_t,versions)
 
-#define DEFINE_xxx_BINARY(x,id,idl,parent,name,versions,global) \
-    DEFINE_xxx_CLASS_BASE(x,EbmlBinary,id,idl,parent,name,versions,global)
+#define DEFINE_xxx_BINARY(x,id,parent,name,versions,global) \
+    DEFINE_xxx_CLASS_BASE(x,EbmlBinary,id,parent,name,versions,global)
 
-#define DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,versions,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUInteger,id,idl,parent,name,global,std::uint64_t,defval, versions)
+#define DEFINE_xxx_UINTEGER_DEF(x,id,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUInteger,id,parent,name,global,std::uint64_t,defval, versions)
 
-#define DEFINE_xxx_SINTEGER_DEF(x,id,idl,parent,name,versions,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlSInteger,id,idl,parent,name,global,std::int64_t,defval, versions)
+#define DEFINE_xxx_SINTEGER_DEF(x,id,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlSInteger,id,parent,name,global,std::int64_t,defval, versions)
 
-#define DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,versions,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlString,id,idl,parent,name,global,const char *,defval, versions)
+#define DEFINE_xxx_STRING_DEF(x,id,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlString,id,parent,name,global,const char *,defval, versions)
 
-#define DEFINE_xxx_UNISTRING_DEF(x,id,idl,parent,name,versions,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUnicodeString,id,idl,parent,name,global,const wchar_t*,defval, versions)
+#define DEFINE_xxx_UNISTRING_DEF(x,id,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlUnicodeString,id,parent,name,global,const wchar_t*,defval, versions)
 
-#define DEFINE_xxx_FLOAT_DEF(x,id,idl,parent,name,versions,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlFloat,id,idl,parent,name,global,double,defval, versions)
+#define DEFINE_xxx_FLOAT_DEF(x,id,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlFloat,id,parent,name,global,double,defval, versions)
 
-#define DEFINE_xxx_DATE_DEF(x,id,idl,parent,name,versions,global,defval) \
-    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,idl,parent,name,versions,global,defval, versions)
+#define DEFINE_xxx_DATE_DEF(x,id,parent,name,versions,global,defval) \
+    DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,parent,name,versions,global,defval, versions)
 
-#define DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    (id, idl); \
+#define DEFINE_xxx_CLASS_ORPHAN(x,id,name,versions,global) \
+    constexpr const libebml::EbmlId Id_##x    {id}; \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x, versions); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,GetEbmlGlobal_Context)
 
-#define DEFINE_EBML_MASTER(x,id,idl,parent,infinite,name,versions)  DEFINE_xxx_MASTER(x,id,idl,parent,infinite,name,versions,GetEbmlGlobal_Context)
-#define DEFINE_EBML_MASTER_ORPHAN(x,id,idl,infinite,name,versions)  DEFINE_xxx_MASTER_ORPHAN(x,id,idl,infinite,name,versions,GetEbmlGlobal_Context)
-#define DEFINE_EBML_CLASS_ORPHAN(x,id,idl,name,versions)            DEFINE_xxx_CLASS_ORPHAN(x,id,idl,name,versions,GetEbmlGlobal_Context)
-#define DEFINE_EBML_UINTEGER_DEF(x,id,idl,parent,name,val,versions) DEFINE_xxx_UINTEGER_DEF(x,id,idl,parent,name,versions,GetEbmlGlobal_Context,val)
-#define DEFINE_EBML_STRING_DEF(x,id,idl,parent,name,val,versions)   DEFINE_xxx_STRING_DEF(x,id,idl,parent,name,versions,GetEbmlGlobal_Context,val)
+#define DEFINE_EBML_MASTER(x,id,parent,infinite,name,versions)  DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,GetEbmlGlobal_Context)
+#define DEFINE_EBML_MASTER_ORPHAN(x,id,infinite,name,versions)  DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,GetEbmlGlobal_Context)
+#define DEFINE_EBML_CLASS_ORPHAN(x,id,name,versions)            DEFINE_xxx_CLASS_ORPHAN(x,id,name,versions,GetEbmlGlobal_Context)
+#define DEFINE_EBML_UINTEGER_DEF(x,id,parent,name,val,versions) DEFINE_xxx_UINTEGER_DEF(x,id,parent,name,versions,GetEbmlGlobal_Context,val)
+#define DEFINE_EBML_STRING_DEF(x,id,parent,name,val,versions)   DEFINE_xxx_STRING_DEF(x,id,parent,name,versions,GetEbmlGlobal_Context,val)
 
 #define DEFINE_SEMANTIC_CONTEXT(x)
 #define DEFINE_START_SEMANTIC(x)     static const libebml::EbmlSemantic ContextList_##x[] = {

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -56,25 +56,25 @@ class EbmlElement;
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; \
+    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
     x::x() :libebml::EbmlMaster(x::ClassInfos) {}
 
 // define a master class with a custom constructor
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; \
+    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions);
 
 // define a master class with no parent class
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; \
+    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; \
+    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x));
 
 #define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,parent,name,versions,global) \
@@ -132,7 +132,7 @@ class EbmlElement;
     DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,parent,name,versions,global,defval, versions)
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,name,versions,global) \
-    constexpr const libebml::EbmlId Id_##x    {id}; \
+    constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
     const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, name, Context_##x, versions); \
 

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -21,12 +21,6 @@ namespace libebml {
 */
 class EBML_DLL_API EbmlId {
   public:
-    constexpr EbmlId(const binary aValue[4], const unsigned int aLength)
-      :Value(FromBuffer(aValue, aLength))
-      ,Length(LengthFromValue(Value))
-    {
-    }
-
     constexpr EbmlId(const std::uint32_t aValue)
       :Value(aValue), Length(LengthFromValue(aValue)) {}
 
@@ -60,6 +54,16 @@ class EBML_DLL_API EbmlId {
       return Value >= 0x10000000;
     }
 
+    static constexpr std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)
+    {
+      std::uint32_t Value = 0;
+      for (unsigned int i=0; i<aLength; i++) {
+        Value <<= 8;
+        Value += aValue[i];
+      }
+      return Value;
+    }
+
   private:
     std::uint32_t Value;
     std::size_t Length;
@@ -72,16 +76,6 @@ class EBML_DLL_API EbmlId {
       if (Value < 0x1000000)
         return 3;
       return 4;
-    }
-
-    static constexpr std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)
-    {
-      std::uint32_t Value = 0;
-      for (unsigned int i=0; i<aLength; i++) {
-        Value <<= 8;
-        Value += aValue[i];
-      }
-      return Value;
     }
 };
 

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -46,8 +46,8 @@ class EBML_DLL_API EbmlId {
       }
     }
 
-        inline std::size_t GetLength() const { return Length; }
-        inline std::uint32_t GetValue() const { return Value; }
+    constexpr std::size_t GetLength() const { return Length; }
+    constexpr std::uint32_t GetValue() const { return Value; }
 
   private:
     std::uint32_t Value;

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -49,6 +49,17 @@ class EBML_DLL_API EbmlId {
     constexpr std::size_t GetLength() const { return Length; }
     constexpr std::uint32_t GetValue() const { return Value; }
 
+    static constexpr bool IsValid(std::uint32_t Value)
+    {
+      if (Value < 0x100)
+        return Value >= 0x80;
+      if (Value < 0x10000)
+        return Value >= 0x4000;
+      if (Value < 0x1000000)
+        return Value >= 0x200000;
+      return Value >= 0x10000000;
+    }
+
   private:
     std::uint32_t Value;
     std::size_t Length;

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -23,12 +23,12 @@ class EBML_DLL_API EbmlId {
   public:
     constexpr EbmlId(const binary aValue[4], const unsigned int aLength)
       :Value(FromBuffer(aValue, aLength))
-      ,Length(aLength)
+      ,Length(LengthFromValue(Value))
     {
     }
 
-    constexpr EbmlId(const std::uint32_t aValue, const unsigned int aLength)
-      :Value(aValue), Length(aLength) {}
+    constexpr EbmlId(const std::uint32_t aValue, const unsigned int /*aLength*/)
+      :Value(aValue), Length(LengthFromValue(aValue)) {}
 
     inline bool operator==(const EbmlId & TestId) const
     {
@@ -52,6 +52,16 @@ class EBML_DLL_API EbmlId {
   private:
     std::uint32_t Value;
     std::size_t Length;
+
+    static constexpr unsigned int LengthFromValue(std::uint32_t Value) {
+      if (Value < 0x100)
+        return 1;
+      if (Value < 0x10000)
+        return 2;
+      if (Value < 0x1000000)
+        return 3;
+      return 4;
+    }
 
     static constexpr std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)
     {

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -27,7 +27,7 @@ class EBML_DLL_API EbmlId {
     {
     }
 
-    constexpr EbmlId(const std::uint32_t aValue, const unsigned int /*aLength*/)
+    constexpr EbmlId(const std::uint32_t aValue)
       :Value(aValue), Length(LengthFromValue(aValue)) {}
 
     inline bool operator==(const EbmlId & TestId) const

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -26,7 +26,7 @@ static constexpr std::uint32_t CRC32_NEGL = 0xffffffffL;
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, 1, "EBMLCrc32\0ratamadabapa", EbmlDocVersion{})
+DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, "EBMLCrc32\0ratamadabapa", EbmlDocVersion{})
 
 static constexpr std::array<std::uint32_t, 256> s_tab {
 #ifdef WORDS_BIGENDIAN

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, 1, "DummyElement", EbmlDocVersion{} )
+DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", EbmlDocVersion{} )
 
 const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
 

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -515,9 +515,6 @@ filepos_t EbmlElement::Render(IOCallback & output, const ShouldWrite& writeFilte
 */
 filepos_t EbmlElement::RenderHead(IOCallback & output, bool bForceRender, const ShouldWrite& writeFilter, bool bKeepPosition)
 {
-  if (EBML_ID_LENGTH((const EbmlId&)*this) <= 0 || EBML_ID_LENGTH((const EbmlId&)*this) > 4)
-    return 0;
-
   UpdateSize(writeFilter, bForceRender);
 
   return MakeRenderHead(output, bKeepPosition);

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -200,7 +200,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
     } while (_SizeLength == 0);
   }
 
-  const auto PossibleID = EbmlId(PossibleId.data(), PossibleID_Length);
+  const auto PossibleID = EbmlId(EbmlId::FromBuffer(PossibleId.data(), PossibleID_Length));
   auto Result = [=] {
     if (PossibleID != EBML_INFO_ID(ClassInfos))
     {
@@ -327,7 +327,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
 
     if (bFound) {
       // find the element in the context and use the correct creator
-      const auto PossibleID = EbmlId(PossibleIdNSize.data(), PossibleID_Length);
+      const auto PossibleID = EbmlId(EbmlId::FromBuffer(PossibleIdNSize.data(), PossibleID_Length));
       EbmlElement * Result = CreateElementUsingContext(PossibleID, Context, UpperLevel, false, SizeFound == SizeUnknown, AllowDummyElt, MaxLowerLevel);
       ///< \todo continue is misplaced
       if (Result != nullptr) {

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -10,13 +10,13 @@
 
 namespace libebml {
 
-DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, 2, EbmlHead, "EBMLVersion", 1, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, 2, EbmlHead, "EBMLReadVersion", 1, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EMaxIdLength,        0x42F2, 2, EbmlHead, "EBMLMaxIdLength", 4, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EMaxSizeLength,      0x42F3, 2, EbmlHead, "EBMLMaxSizeLength", 8, EbmlDocVersion{})
-DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, 2, EbmlHead, "EBMLDocType", "matroska", EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, 2, EbmlHead, "EBMLDocTypeVersion", 1, EbmlDocVersion{})
-DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, 2, EbmlHead, "EBMLDocTypeReadVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, EbmlHead, "EBMLVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, EbmlHead, "EBMLReadVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EMaxIdLength,        0x42F2, EbmlHead, "EBMLMaxIdLength", 4, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EMaxSizeLength,      0x42F3, EbmlHead, "EBMLMaxSizeLength", 8, EbmlDocVersion{})
+DEFINE_EBML_STRING_DEF  (EDocType,            0x4282, EbmlHead, "EBMLDocType", "matroska", EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EDocTypeVersion,     0x4287, EbmlHead, "EBMLDocTypeVersion", 1, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(EDocTypeReadVersion, 0x4285, EbmlHead, "EBMLDocTypeReadVersion", 1, EbmlDocVersion{})
 
 DEFINE_START_SEMANTIC(EbmlHead)
 DEFINE_SEMANTIC_ITEM(true, true, EVersion)        ///< EBMLVersion
@@ -28,7 +28,7 @@ DEFINE_SEMANTIC_ITEM(true, true, EDocTypeVersion) ///< DocTypeVersion
 DEFINE_SEMANTIC_ITEM(true, true, EDocTypeReadVersion) ///< DocTypeReadVersion
 DEFINE_END_SEMANTIC(EbmlHead)
 
-DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, 4, false, "EBMLHead\0ratamapaga", EbmlDocVersion{})
+DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, false, "EBMLHead\0ratamapaga", EbmlDocVersion{})
 
 EbmlHead::EbmlHead()
   :EbmlMaster(EbmlHead::ClassInfos)

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, 1, "EBMLVoid", EbmlDocVersion{})
+DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, "EBMLVoid", EbmlDocVersion{})
 
 EbmlVoid::EbmlVoid()
   :EbmlBinary(EbmlVoid::ClassInfos)

--- a/test/test_id.cxx
+++ b/test/test_id.cxx
@@ -39,5 +39,14 @@ int main(void)
     if (id.GetLength() != 3)
         return 1;
 
+    constexpr EbmlId test1{0xA3, 1};
+    static_assert(test1.GetLength() == 1, "nope");
+    constexpr EbmlId test2{0x5854, 2};
+    static_assert(test2.GetLength() == 2, "nope");
+    constexpr EbmlId test3{0x654000, 3};
+    static_assert(test3.GetLength() == 3, "nope");
+    constexpr EbmlId test4{0x1A45DFA3, 4};
+    static_assert(test4.GetLength() == 4, "nope");
+
     return 0;
 }

--- a/test/test_id.cxx
+++ b/test/test_id.cxx
@@ -15,7 +15,7 @@ public:
 int main(void)
 {
     constexpr binary buf[4] = { 0x12, 0x34, 0x56, 0x78 };
-    EbmlId frombuf(buf, 4);
+    EbmlId frombuf(EbmlId::FromBuffer(buf, 4));
 
     EbmlId fromint(0x12345678);
 

--- a/test/test_id.cxx
+++ b/test/test_id.cxx
@@ -5,7 +5,7 @@
 
 using namespace libebml;
 
-static constexpr EbmlId MyId = EbmlId{0x654321, 3};
+static constexpr EbmlId MyId = EbmlId{0x654321};
 
 class KaxTracks {
 public:
@@ -17,7 +17,7 @@ int main(void)
     constexpr binary buf[4] = { 0x12, 0x34, 0x56, 0x78 };
     EbmlId frombuf(buf, 4);
 
-    EbmlId fromint(0x12345678, 4);
+    EbmlId fromint(0x12345678);
 
     EbmlId copy(fromint);
     binary read[4];
@@ -30,7 +30,7 @@ int main(void)
     if (read[0] != 0x12 || read[1] != 0x34 || read[2] != 0x56 || read[3] != 0x78)
         return 1;
 
-    EbmlId id{42, 1};
+    EbmlId id{42};
     if (id.GetLength() != 1)
         return 1;
 
@@ -39,13 +39,13 @@ int main(void)
     if (id.GetLength() != 3)
         return 1;
 
-    constexpr EbmlId test1{0xA3, 1};
+    constexpr EbmlId test1{0xA3};
     static_assert(test1.GetLength() == 1, "nope");
-    constexpr EbmlId test2{0x5854, 2};
+    constexpr EbmlId test2{0x5854};
     static_assert(test2.GetLength() == 2, "nope");
-    constexpr EbmlId test3{0x654000, 3};
+    constexpr EbmlId test3{0x654000};
     static_assert(test3.GetLength() == 3, "nope");
-    constexpr EbmlId test4{0x1A45DFA3, 4};
+    constexpr EbmlId test4{0x1A45DFA3};
     static_assert(test4.GetLength() == 4, "nope");
 
     return 0;

--- a/test/test_infinite.cxx
+++ b/test/test_infinite.cxx
@@ -27,10 +27,10 @@ DECLARE_xxx_MASTER(NoInfinite,)
 EBML_CONCRETE_CLASS(NoInfinite)
 };
 
-DEFINE_EBML_MASTER_ORPHAN(CanInfinite, 0xF0, 1, true, "CanInfinite", EbmlDocVersion{})
-DEFINE_EBML_MASTER_ORPHAN(NoInfinite, 0xF0, 1, false, "NoInfinite", EbmlDocVersion{})
+DEFINE_EBML_MASTER_ORPHAN(CanInfinite, 0xF0, true, "CanInfinite", EbmlDocVersion{})
+DEFINE_EBML_MASTER_ORPHAN(NoInfinite, 0xF0, false, "NoInfinite", EbmlDocVersion{})
 
-DEFINE_EBML_UINTEGER_DEF(DummyChild, 0x42F7, 2, CanInfinite, "DummyChild", 0, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(DummyChild, 0x42F7, CanInfinite, "DummyChild", 0, EbmlDocVersion{})
 
 CanInfinite::CanInfinite()
     :EbmlMaster(CanInfinite::ClassInfos)

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -8,32 +8,32 @@ using namespace libebml;
 DECLARE_EBML_STRING_DEF(StringWithDefault)
     EBML_CONCRETE_CLASS(StringWithDefault)
 };
-DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, 2, EbmlHead, "StringWithDefault", "Default Value", EbmlDocVersion{})
+DEFINE_EBML_STRING_DEF(StringWithDefault, 0x4321, EbmlHead, "StringWithDefault", "Default Value", EbmlDocVersion{})
 
 DECLARE_xxx_STRING(StringWithoutDefault,)
     EBML_CONCRETE_CLASS(StringWithoutDefault)
 };
-DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, 2, EbmlHead, "StringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
+DEFINE_xxx_STRING(StringWithoutDefault, 0x4123, EbmlHead, "StringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
 
 DECLARE_xxx_UNISTRING_DEF(UniStringWithDefault,)
     EBML_CONCRETE_CLASS(UniStringWithDefault)
 };
-DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, 2, EbmlHead, "UniStringWithDefault", EbmlDocVersion{}, GetEbmlGlobal_Context, L"Default Value")
+DEFINE_xxx_UNISTRING_DEF(UniStringWithDefault, 0x4321, EbmlHead, "UniStringWithDefault", EbmlDocVersion{}, GetEbmlGlobal_Context, L"Default Value")
 
 DECLARE_xxx_UNISTRING(UniStringWithoutDefault,)
     EBML_CONCRETE_CLASS(UniStringWithoutDefault)
 };
-DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, 2, EbmlHead, "UniStringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
+DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, EbmlHead, "UniStringWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
 
 DECLARE_EBML_UINTEGER_DEF(UIntWithDefault)
     EBML_CONCRETE_CLASS(UIntWithDefault)
 };
-DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, 3, EbmlHead, "UIntWithDefault", 42, EbmlDocVersion{})
+DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, EbmlHead, "UIntWithDefault", 42, EbmlDocVersion{})
 
 DECLARE_xxx_UINTEGER(UIntWithoutDefault,)
     EBML_CONCRETE_CLASS(UIntWithoutDefault)
 };
-DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, 3, EbmlHead, "UIntWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
+DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, EbmlHead, "UIntWithoutDefault", EbmlDocVersion{}, GetEbmlGlobal_Context)
 
 int main(void)
 {


### PR DESCRIPTION
Maybe it's possible with std::enable_if but I haven't managed to do it. Not sure it would be usable on reading though.

We don't need to pass the length of the ID anymore (we may not even store it anymore).

libmatroska will need this to build https://github.com/Matroska-Org/libmatroska/pull/169