### PR TITLE
pass std::function by const ref

### DIFF
--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -34,7 +34,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
 
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     void SetBuffer(const binary *Buffer, const std::uint32_t BufferSize) {
       Data = const_cast<binary *>(Buffer);

--- a/ebml/EbmlBinary.h
+++ b/ebml/EbmlBinary.h
@@ -32,7 +32,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
 
     bool SizeIsValid(std::uint64_t size) const override {return size < 0x7FFFFFFF;} // we don't mind about what's inside
 
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -17,7 +17,7 @@ DECLARE_EBML_BINARY_LENGTH(EbmlCrc32, 4)
   public:
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-//    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault);
+//    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault) override;
 
     bool IsDefaultValue() const override {
       return false;

--- a/ebml/EbmlCrc32.h
+++ b/ebml/EbmlCrc32.h
@@ -15,7 +15,7 @@ namespace libebml {
 
 DECLARE_EBML_BINARY_LENGTH(EbmlCrc32, 4)
   public:
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
 //    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault) override;
 

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -46,7 +46,7 @@ class EBML_DLL_API EbmlDate : public EbmlElementDefaultSameStorage<std::int64_t>
     /*!
       \note no Default date handled
     */
-    filepos_t UpdateSize(ShouldWrite /* writeFilter */, bool /* bForceRender = false */) override {
+    filepos_t UpdateSize(const ShouldWrite & /* writeFilter */, bool /* bForceRender = false */) override {
       if(!ValueIsSet())
         SetSize_(0);
       else

--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -68,7 +68,7 @@ class EBML_DLL_API EbmlDate : public EbmlElementDefaultSameStorage<std::int64_t>
     }
 
     private:
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
 
     static constexpr std::uint64_t UnixEpochDelay = 978'307'200; // 2001/01/01 00:00:00 UTC
 };

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -587,7 +587,7 @@ class EBML_DLL_API EbmlElement {
     /*!
       \brief prepare the data before writing them (in case it's not already done by default)
     */
-    virtual filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) = 0;
+    virtual filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) = 0;
 
     /*!
       \brief special constructor for cloning

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -520,7 +520,7 @@ class EBML_DLL_API EbmlElement {
 
     filepos_t Render(IOCallback & output, ShouldWrite writeFilter = WriteSkipDefault, bool bKeepPosition = false, bool bForceRender = false);
 
-    virtual filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) = 0; /// update the Size of the Data stored
+    virtual filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) = 0; /// update the Size of the Data stored
     virtual filepos_t GetSize() const {return Size;} /// return the size of the data stored in the element, on reading
 
     virtual filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) = 0;
@@ -568,7 +568,7 @@ class EBML_DLL_API EbmlElement {
       return SizePosition + CodedSizeLength(Size, SizeLength, bSizeIsFinite) + Size;
     }
 
-    virtual bool CanWrite(ShouldWrite & writeFilter) const {
+    virtual bool CanWrite(const ShouldWrite & writeFilter) const {
       return writeFilter(*this);
     }
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -516,9 +516,9 @@ class EBML_DLL_API EbmlElement {
       return ElementPosition;
     }
 
-    std::uint64_t ElementSize(ShouldWrite writeFilter = WriteSkipDefault) const; /// return the size of the header+data, before writing
+    std::uint64_t ElementSize(const ShouldWrite& writeFilter = WriteSkipDefault) const; /// return the size of the header+data, before writing
 
-    filepos_t Render(IOCallback & output, ShouldWrite writeFilter = WriteSkipDefault, bool bKeepPosition = false, bool bForceRender = false);
+    filepos_t Render(IOCallback & output, const ShouldWrite& writeFilter = WriteSkipDefault, bool bKeepPosition = false, bool bForceRender = false);
 
     virtual filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) = 0; /// update the Size of the Data stored
     virtual filepos_t GetSize() const {return Size;} /// return the size of the data stored in the element, on reading
@@ -551,7 +551,7 @@ class EBML_DLL_API EbmlElement {
     /*!
       \brief void the content of the element (replace by EbmlVoid)
     */
-    std::uint64_t VoidMe(IOCallback & output, ShouldWrite writeFilter = WriteSkipDefault) const;
+    std::uint64_t VoidMe(IOCallback & output, const ShouldWrite& writeFilter = WriteSkipDefault) const;
 
     virtual bool IsDefaultValue() const = 0;
     bool IsFiniteSize() const {return bSizeIsFinite;}
@@ -581,7 +581,7 @@ class EBML_DLL_API EbmlElement {
                                                   bool AsInfiniteSize,
                                                   bool bAllowDummy = false, unsigned int MaxLowerLevel = 1);
 
-    filepos_t RenderHead(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault, bool bKeepPosition = false);
+    filepos_t RenderHead(IOCallback & output, bool bForceRender, const ShouldWrite& writeFilter = WriteSkipDefault, bool bKeepPosition = false);
     filepos_t MakeRenderHead(IOCallback & output, bool bKeepPosition);
 
     /*!

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -30,7 +30,7 @@ class EBML_DLL_API EbmlFloat : public EbmlElementDefaultSameStorage<double> {
       return (size == 4 || size == 8);
     }
 
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlFloat.h
+++ b/ebml/EbmlFloat.h
@@ -32,7 +32,7 @@ class EBML_DLL_API EbmlFloat : public EbmlElementDefaultSameStorage<double> {
 
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     void SetPrecision(const EbmlFloat::Precision prec = FLOAT_32)
     {

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -39,7 +39,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
 
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     bool PushElement(EbmlElement & element);
     std::uint64_t GetSize() const override {

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -37,7 +37,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     */
     ~EbmlMaster() override;
 
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -127,7 +127,7 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     /*!
       \brief facility for Master elements to write only the head and force the size later
     */
-    filepos_t WriteHead(IOCallback & output, int SizeLength, ShouldWrite writeFilter = WriteSkipDefault);
+    filepos_t WriteHead(IOCallback & output, int SizeLength, const ShouldWrite& writeFilter = WriteSkipDefault);
 
     void EnableChecksum(bool bIsEnabled = true) { bChecksumUsed = bIsEnabled; }
     bool HasChecksum() const {return bChecksumUsed;}

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -32,7 +32,7 @@ class EBML_DLL_API EbmlSInteger : public EbmlElementDefaultSameStorage<std::int6
         void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_INT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
     bool SizeIsValid(std::uint64_t size) const override {return size <= 8;}
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlSInteger.h
+++ b/ebml/EbmlSInteger.h
@@ -34,7 +34,7 @@ class EBML_DLL_API EbmlSInteger : public EbmlElementDefaultSameStorage<std::int6
     bool SizeIsValid(std::uint64_t size) const override {return size <= 8;}
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     using EbmlElement::operator const EbmlId &;
     explicit operator std::int8_t() const;

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -25,7 +25,7 @@ class EBML_DLL_API EbmlString : public EbmlElementDefaultStorage<const char *, s
     bool SizeIsValid(std::uint64_t size) const override {return size < 0x7FFFFFFF;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     using EbmlElement::operator const EbmlId &;
 

--- a/ebml/EbmlString.h
+++ b/ebml/EbmlString.h
@@ -23,7 +23,7 @@ class EBML_DLL_API EbmlString : public EbmlElementDefaultStorage<const char *, s
     EbmlString(const EbmlCallbacksDefault<const char *> &);
 
     bool SizeIsValid(std::uint64_t size) const override {return size < 0x7FFFFFFF;} // any size is possible
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -32,7 +32,7 @@ class EBML_DLL_API EbmlUInteger : public EbmlElementDefaultSameStorage<std::uint
     bool SizeIsValid(std::uint64_t size) const override {return size <= 8;}
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     using EbmlElement::operator const EbmlId &;
     explicit operator std::uint8_t()  const;

--- a/ebml/EbmlUInteger.h
+++ b/ebml/EbmlUInteger.h
@@ -30,7 +30,7 @@ class EBML_DLL_API EbmlUInteger : public EbmlElementDefaultSameStorage<std::uint
     void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_UINT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
 
     bool SizeIsValid(std::uint64_t size) const override {return size <= 8;}
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -71,7 +71,7 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElementDefaultStorage<const wc
     bool SizeIsValid(std::uint64_t /*size*/) const override {return true;} // any size is possible
     filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
-    filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
+    filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 
     using EbmlElement::operator const EbmlId &;
 

--- a/ebml/EbmlUnicodeString.h
+++ b/ebml/EbmlUnicodeString.h
@@ -69,7 +69,7 @@ class EBML_DLL_API EbmlUnicodeString : public EbmlElementDefaultStorage<const wc
     EbmlUnicodeString(const EbmlCallbacksDefault<const wchar_t *> &);
 
     bool SizeIsValid(std::uint64_t /*size*/) const override {return true;} // any size is possible
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/ebml/EbmlVoid.h
+++ b/ebml/EbmlVoid.h
@@ -22,7 +22,7 @@ DECLARE_EBML_BINARY(EbmlVoid)
     /*!
       \note overwrite to write fake data
     */
-    filepos_t RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
+    filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
 
     /*!
       \brief Replace the void element content (written) with this one

--- a/ebml/EbmlVoid.h
+++ b/ebml/EbmlVoid.h
@@ -27,12 +27,12 @@ DECLARE_EBML_BINARY(EbmlVoid)
     /*!
       \brief Replace the void element content (written) with this one
     */
-    std::uint64_t ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, ShouldWrite writeFilter = WriteSkipDefault);
+    std::uint64_t ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, const ShouldWrite& writeFilter = WriteSkipDefault);
 
     /*!
       \brief Void the content of an element
     */
-    std::uint64_t Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, ShouldWrite writeFilter = WriteSkipDefault);
+    std::uint64_t Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, const ShouldWrite& writeFilter = WriteSkipDefault);
 
         EBML_CONCRETE_CLASS(EbmlVoid)
 };

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -59,7 +59,7 @@ filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, S
 /*!
   \note no Default binary value handled
 */
-std::uint64_t EbmlBinary::UpdateSize(ShouldWrite /* writeFilter */, bool /* bForceRender */)
+std::uint64_t EbmlBinary::UpdateSize(const ShouldWrite & /* writeFilter */, bool /* bForceRender */)
 {
   return GetSize();
 }

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -49,7 +49,7 @@ EbmlBinary::~EbmlBinary() {
 EbmlBinary::operator const binary &() const {return *Data;}
 
 
-filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   output.writeFully(Data,GetSize());
 

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -184,7 +184,7 @@ bool EbmlCrc32::CheckElementCRC32(EbmlElement &ElementToCRC) const
   return CheckCRC(m_crc_final, memoryBuffer.GetDataBuffer(), static_cast<std::uint32_t>(memSize));
 }
 
-filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlCrc32::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   filepos_t Result = 4;
 

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -31,7 +31,7 @@ filepos_t EbmlDate::ReadData(IOCallback & input, ScopeMode ReadFully)
   return GetSize();
 }
 
-filepos_t EbmlDate::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlDate::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   assert(GetSize() == 8 || GetSize() == 0);
   if (GetSize() == 8) {

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -488,7 +488,7 @@ EbmlElement *EbmlElement::CreateElementUsingContext(const EbmlId & aID, const Eb
 /*!
   \todo verify that the size written is the same as the data written
 */
-filepos_t EbmlElement::Render(IOCallback & output, ShouldWrite writeFilter, bool bKeepPosition, bool bForceRender)
+filepos_t EbmlElement::Render(IOCallback & output, const ShouldWrite& writeFilter, bool bKeepPosition, bool bForceRender)
 {
   assert(bValueIsSet || CanWrite(writeFilter)); // an element is been rendered without a value set !!!
   // it may be a mandatory element without a default value
@@ -513,7 +513,7 @@ filepos_t EbmlElement::Render(IOCallback & output, ShouldWrite writeFilter, bool
   \todo handle exceptions on errors
   \todo handle CodeSize bigger than 5 bytes
 */
-filepos_t EbmlElement::RenderHead(IOCallback & output, bool bForceRender, ShouldWrite writeFilter, bool bKeepPosition)
+filepos_t EbmlElement::RenderHead(IOCallback & output, bool bForceRender, const ShouldWrite& writeFilter, bool bKeepPosition)
 {
   if (EBML_ID_LENGTH((const EbmlId&)*this) <= 0 || EBML_ID_LENGTH((const EbmlId&)*this) > 4)
     return 0;
@@ -544,7 +544,7 @@ filepos_t EbmlElement::MakeRenderHead(IOCallback & output, bool bKeepPosition)
   return FinalHeadSize;
 }
 
-std::uint64_t EbmlElement::ElementSize(ShouldWrite writeFilter) const
+std::uint64_t EbmlElement::ElementSize(const ShouldWrite& writeFilter) const
 {
   if (!CanWrite(writeFilter))
     return 0; // won't be saved
@@ -622,7 +622,7 @@ filepos_t EbmlElement::OverwriteData(IOCallback & output, bool bKeepPosition)
 }
 
 
-std::uint64_t EbmlElement::VoidMe(IOCallback & output, ShouldWrite writeFilter) const
+std::uint64_t EbmlElement::VoidMe(IOCallback & output, const ShouldWrite& writeFilter) const
 {
   if (ElementPosition == 0) {
     return 0; // the element has not been written

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -53,7 +53,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, Sh
   return GetSize();
 }
 
-std::uint64_t EbmlFloat::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
+std::uint64_t EbmlFloat::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -30,7 +30,7 @@ EbmlFloat::operator double() const {return (GetValue());}
   \todo handle exception on errors
   \todo handle 10 bits precision
 */
-filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   assert(GetSize() == 4 || GetSize() == 8);
 

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -126,7 +126,7 @@ std::uint64_t EbmlMaster::UpdateSize(const ShouldWrite & writeFilter, bool bForc
   return GetSize();
 }
 
-filepos_t EbmlMaster::WriteHead(IOCallback & output, int nSizeLength, ShouldWrite writeFilter)
+filepos_t EbmlMaster::WriteHead(IOCallback & output, int nSizeLength, const ShouldWrite& writeFilter)
 {
   SetSizeLength(nSizeLength);
   return RenderHead(output, false, writeFilter);

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -97,7 +97,7 @@ bool EbmlMaster::PushElement(EbmlElement & element)
   return false;
 }
 
-std::uint64_t EbmlMaster::UpdateSize(ShouldWrite writeFilter, bool bForceRender)
+std::uint64_t EbmlMaster::UpdateSize(const ShouldWrite & writeFilter, bool bForceRender)
 {
   SetSize_(0);
 

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -47,7 +47,7 @@ EbmlMaster::~EbmlMaster()
   \todo handle exception on errors
   \todo write all the Mandatory elements in the Context, otherwise assert
 */
-filepos_t EbmlMaster::RenderData(IOCallback & output, bool bForceRender, ShouldWrite writeFilter)
+filepos_t EbmlMaster::RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter)
 {
   filepos_t Result = 0;
 

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -67,7 +67,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-std::uint64_t EbmlSInteger::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
+std::uint64_t EbmlSInteger::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -48,7 +48,7 @@ EbmlSInteger::operator std::int64_t() const {return GetValue();}
 /*!
   \todo handle exception on errors
 */
-filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   std::array<binary, 8> FinalData; // we don't handle more than 64 bits integers
   unsigned int i;

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -40,7 +40,7 @@ filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, S
   return Result;
 }
 
-std::uint64_t EbmlString::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
+std::uint64_t EbmlString::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -24,7 +24,7 @@ EbmlString::EbmlString(const EbmlCallbacksDefault<const char *> & classInfo)
 /*!
   \todo handle exception on errors
 */
-filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   filepos_t Result;
   output.writeFully(Value.c_str(), Value.length());

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -49,7 +49,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-std::uint64_t EbmlUInteger::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
+std::uint64_t EbmlUInteger::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -31,7 +31,7 @@ EbmlUInteger::operator std::uint64_t() const {return GetValue();}
 /*!
   \todo handle exception on errors
 */
-filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   std::array<binary, 8> FinalData; // we don't handle more than 64 bits integers
 

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -113,7 +113,7 @@ EbmlUnicodeString::EbmlUnicodeString(const EbmlCallbacksDefault<const wchar_t *>
 \note limited to UCS-2
 \todo handle exception on errors
 */
-filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   std::size_t Result = Value.GetUTF8().length();
 

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -144,7 +144,7 @@ std::string EbmlUnicodeString::GetValueUTF8() const {
 /*!
 \note limited to UCS-2
 */
-std::uint64_t EbmlUnicodeString::UpdateSize(ShouldWrite writeFilter, bool /* bForceRender */)
+std::uint64_t EbmlUnicodeString::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -18,7 +18,7 @@ EbmlVoid::EbmlVoid()
   SetValueIsSet();
 }
 
-filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite /* writeFilter */)
+filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, const ShouldWrite & /* writeFilter */)
 {
   // write dummy data by 4KB chunks
   static binary DummyBuf[4*1024];

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -32,7 +32,7 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, Sho
   return GetSize();
 }
 
-std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, ShouldWrite writeFilter)
+std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, const ShouldWrite& writeFilter)
 {
   EltToReplaceWith.UpdateSize(writeFilter);
   if (HeadSize() + GetSize() < EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize()) {
@@ -69,7 +69,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   return GetSize() + HeadSize();
 }
 
-std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, ShouldWrite writeFilter)
+std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, const ShouldWrite& writeFilter)
 {
   //  EltToVoid.UpdateSize(bWithDefault);
   if (EltToVoid.GetElementPosition() == 0) {


### PR DESCRIPTION
Too expensive to pass by value.

@robUx4 