### PR TITLE
declare EbmlDummy constructor in cpp file

### DIFF
--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -14,7 +14,7 @@ namespace libebml {
 
 class EBML_DLL_API EbmlDummy : public EbmlBinary {
   public:
-    EbmlDummy(const EbmlId & aId) : EbmlBinary(EbmlDummy::ClassInfos), DummyId(aId) {}
+    EbmlDummy(const EbmlId & aId);
 
     bool IsDummy() const override {return true;}
     bool IsDefaultValue() const override {return true;}

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -14,6 +14,8 @@ static constexpr EbmlDocVersion AllEbmlVersions{};
 
 DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", AllEbmlVersions )
 
+EbmlDummy::EbmlDummy(const EbmlId & aId) : EbmlBinary(EbmlDummy::ClassInfos), DummyId(aId) {}
+
 const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
 
 } // namespace libebml


### PR DESCRIPTION
Fixes compilation on GCC7-9 for some reason.