### PR TITLE
fix newer clang compile

### DIFF
--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -27,7 +27,7 @@ namespace libebml {
 
 static constexpr EbmlDocVersion AllEbmlVersions{};
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, "EBMLCrc32\0ratamadabapa", AllEbmlVersions)
+DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, "EBMLCrc32", AllEbmlVersions)
 
 static constexpr std::array<std::uint32_t, 256> s_tab {
 #ifdef WORDS_BIGENDIAN

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -30,7 +30,7 @@ DEFINE_SEMANTIC_ITEM(true, true, EDocTypeVersion) ///< DocTypeVersion
 DEFINE_SEMANTIC_ITEM(true, true, EDocTypeReadVersion) ///< DocTypeReadVersion
 DEFINE_END_SEMANTIC(EbmlHead)
 
-DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, false, "EBMLHead\0ratamapaga", AllEbmlVersions)
+DEFINE_EBML_MASTER_ORPHAN(EbmlHead, 0x1A45DFA3, false, "EBMLHead", AllEbmlVersions)
 
 EbmlHead::EbmlHead()
   :EbmlMaster(EbmlHead::ClassInfos)


### PR DESCRIPTION
Newer clang is more strict regarding \0 in constexpr.