### PR TITLE
Reduce the number of methods and cleanup some macros

### DIFF
--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -27,7 +27,6 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
     EbmlElement * Clone() const override { return new EbmlDummy(DummyId); }
 
     static EbmlElement & Create() { return *(new EbmlDummy(DummyRawId)); }
-    static const EbmlId & ClassId() { return DummyRawId; };
     static const EbmlCallbacks ClassInfos;
 
   private:

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -31,7 +31,7 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
 
   private:
     const EbmlId DummyId;
-    static const EbmlId DummyRawId;
+    static constexpr EbmlId DummyRawId{0xFF};
 };
 
 } // namespace libebml

--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -15,6 +15,7 @@ namespace libebml {
 class EBML_DLL_API EbmlDummy : public EbmlBinary {
   public:
     EbmlDummy(const EbmlId & aId);
+    EbmlDummy() :EbmlDummy(DummyRawId) {}
 
     bool IsDummy() const override {return true;}
     bool IsDefaultValue() const override {return true;}
@@ -26,7 +27,7 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
     EbmlElement & CreateElement() const override { return Create(); }
     EbmlElement * Clone() const override { return new EbmlDummy(DummyId); }
 
-    static EbmlElement & Create() { return *(new EbmlDummy(DummyRawId)); }
+    static EbmlElement & Create() { return *(new EbmlDummy()); }
     static const EbmlCallbacks ClassInfos;
 
   private:

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -251,7 +251,9 @@ class DllApi x : public BaseClass { \
 #define EBML_INFO_ID(cb)      (cb).ClassId()
 #define EBML_INFO_NAME(cb)    (cb).GetName()
 #define EBML_INFO_CREATE(cb)  (cb).NewElement()
+#define EBML_INFO_CONTEXT(cb) (cb).GetContext()
 
+#define EBML_SEM_SPECS(s)   (s).GetCallbacks()
 #define EBML_SEM_CONTEXT(s) ((const libebml::EbmlCallbacks &)(s)).GetContext()
 #define EBML_SEM_CREATE(s)  (s).Create()
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -483,7 +483,7 @@ class EBML_DLL_API EbmlElement {
     */
     virtual EbmlElement * Clone() const = 0;
 
-    virtual EbmlId const &GetClassId() const {return ClassInfo.ClassId();}
+    virtual EbmlId const &GetClassId() const {return EBML_INFO_ID(ClassInfo);}
     virtual explicit operator const EbmlId &() const { return GetClassId(); }
     constexpr const char *DebugName() const {return ClassInfo.GetName();}
     constexpr const EbmlSemanticContext &Context() const {return ClassInfo.GetContext();}

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -244,7 +244,7 @@ class DllApi x : public BaseClass { \
 #define EBML_INFO(ref)             ref::ClassInfo()
 #define EBML_ID(ref)               ref::ClassId()
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
-#define EBML_CLASS_CONTEXT(ref)    ref::ClassInfo().GetContext()
+#define EBML_CLASS_CONTEXT(ref)    EBML_INFO_CONTEXT(EBML_INFO(ref))
 #define EBML_CONTEXT(e) (e)->Context()
 #define EBML_NAME(e)    (e)->DebugName()
 
@@ -254,15 +254,15 @@ class DllApi x : public BaseClass { \
 #define EBML_INFO_CONTEXT(cb) (cb).GetContext()
 
 #define EBML_SEM_SPECS(s)   (s).GetCallbacks()
-#define EBML_SEM_CONTEXT(s) ((const libebml::EbmlCallbacks &)(s)).GetContext()
+#define EBML_SEM_CONTEXT(s) EBML_INFO_CONTEXT(EBML_SEM_SPECS(s))
 #define EBML_SEM_CREATE(s)  (s).Create()
 
 #define EBML_CTX_SIZE(c)       (c).GetSize()
 #define EBML_CTX_MASTER(c)     (c).GetMaster()
 #define EBML_CTX_PARENT(c)     (c).Parent()
 #define EBML_CTX_IDX(c,i)      (c).GetSemantic(i)
-#define EBML_CTX_IDX_INFO(c,i) (const libebml::EbmlCallbacks &)((c).GetSemantic(i))
-#define EBML_CTX_IDX_ID(c,i)   ((const libebml::EbmlCallbacks &)((c).GetSemantic(i))).ClassId()
+#define EBML_CTX_IDX_INFO(c,i) EBML_SEM_SPECS(EBML_CTX_IDX(c,i))
+#define EBML_CTX_IDX_ID(c,i)   EBML_INFO_ID(EBML_CTX_IDX_INFO(c,i))
 
 #if !defined(INVALID_FILEPOS_T)
 #define INVALID_FILEPOS_T 0

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -54,29 +54,29 @@ class EbmlSemanticContext;
 class EbmlElement;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
+    constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, false, name, Context_##x, versions); \
     x::x() :libebml::EbmlMaster(x::ClassInfos) {}
 
 // define a master class with a custom constructor
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, false, name, Context_##x, versions);
 
 // define a master class with no parent class
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, false, name, Context_##x, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x));
+    constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, &Context_##parent, global, &EBML_INFO(x));
 
 #define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,parent,name,versions,global) \
     DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
@@ -134,7 +134,7 @@ class EbmlElement;
 
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
+    static constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(0, nullptr, nullptr, global, nullptr); \
     constexpr const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, false, false, name, Context_##x, versions); \
 
 #define DEFINE_EBML_CONTEXT(x)                             DEFINE_xxx_CONTEXT(x,GetEbmlGlobal_Context)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -146,7 +146,7 @@ class EbmlElement;
 #define DEFINE_EBML_STRING_DEF(x,id,parent,name,val,versions)   DEFINE_xxx_STRING_DEF(x,id,parent,name,versions,GetEbmlGlobal_Context,val)
 
 #define DEFINE_SEMANTIC_CONTEXT(x)
-#define DEFINE_START_SEMANTIC(x)     static const libebml::EbmlSemantic ContextList_##x[] = {
+#define DEFINE_START_SEMANTIC(x)     static constexpr const libebml::EbmlSemantic ContextList_##x[] = {
 #define DEFINE_END_SEMANTIC(x)       };
 #define DEFINE_SEMANTIC_ITEM(m,u,c)  libebml::EbmlSemantic(m, u, EBML_INFO(c)),
 #define DEFINE_SEMANTIC_ITEM_UINT(m,u,d,c)      EbmlSemantic(m, u, static_cast<std::uint64_t>(d), EBML_INFO(c)),

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -320,7 +320,9 @@ class EBML_DLL_API EbmlDocVersion {
 */
 class EBML_DLL_API EbmlCallbacks {
   public:
-    constexpr EbmlCallbacks(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, bool aCanInfinite, bool aHasDefault, const char * aDebugName, const EbmlSemanticContext & aContext,
+    using CreateOperator = EbmlElement & (*)(void);
+
+    constexpr EbmlCallbacks(const CreateOperator & Creator, const EbmlId & aGlobalId, bool aCanInfinite, bool aHasDefault, const char * aDebugName, const EbmlSemanticContext & aContext,
                             const EbmlDocVersion & aVersion)
       :Create(Creator)
       ,GlobalId(aGlobalId)
@@ -343,7 +345,7 @@ class EBML_DLL_API EbmlCallbacks {
         inline constexpr const EbmlDocVersion & GetVersions() const { return Version; }
 
     private:
-    EbmlElement & (* const Create)();
+    const CreateOperator Create;
     const EbmlId & GlobalId;
     const bool CanInfinite;
     const bool hasDefault;

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -239,10 +239,9 @@ class DllApi x : public BaseClass { \
         libebml::EbmlElement * Clone() const override { return new Type(*this); } \
     static libebml::EbmlElement & Create() {return *(new Type);} \
         static constexpr const libebml::EbmlCallbacks & ClassInfo() {return ClassInfos;} \
-        static const libebml::EbmlId & ClassId() {return ClassInfos.ClassId();} \
 
 #define EBML_INFO(ref)             ref::ClassInfo()
-#define EBML_ID(ref)               ref::ClassId()
+#define EBML_ID(ref)               EBML_INFO_ID(EBML_INFO(ref))
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
 #define EBML_CLASS_CONTEXT(ref)    EBML_INFO_CONTEXT(EBML_INFO(ref))
 #define EBML_CONTEXT(e) (e)->Context()

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -390,7 +390,6 @@ class EBML_DLL_API EbmlSemantic {
         inline constexpr bool IsMandatory() const { return Mandatory; }
         inline constexpr bool IsUnique() const { return Unique; }
         inline EbmlElement & Create() const { return EBML_INFO_CREATE(Callbacks); }
-        inline explicit operator const EbmlCallbacks &() const { return Callbacks; }
         inline constexpr EbmlCallbacks const &GetCallbacks() const { return Callbacks; }
 
     private:

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -16,6 +16,4 @@ DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", AllEbmlVersions )
 
 EbmlDummy::EbmlDummy(const EbmlId & aId) : EbmlBinary(EbmlDummy::ClassInfos), DummyId(aId) {}
 
-const EbmlId EbmlDummy::DummyRawId = Id_EbmlDummy;
-
 } // namespace libebml

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -427,10 +427,9 @@ EbmlElement *EbmlElement::CreateElementUsingContext(const EbmlId & aID, const Eb
   // elements at the current level
   for (unsigned int ContextIndex = 0; ContextIndex < EBML_CTX_SIZE(Context); ContextIndex++) {
     if (aID == EBML_CTX_IDX_ID(Context,ContextIndex)) {
-      auto ClassInfos = EBML_CTX_IDX(Context,ContextIndex);
-      if (AsInfiniteSize && !ClassInfos.GetCallbacks().CanHaveInfiniteSize())
+      if (AsInfiniteSize && !EBML_CTX_IDX_INFO(Context,ContextIndex).CanHaveInfiniteSize())
         return nullptr;
-      Result = &EBML_SEM_CREATE(ClassInfos);
+      Result = &EBML_SEM_CREATE(EBML_CTX_IDX(Context,ContextIndex));
       Result->SetSizeInfinite(AsInfiniteSize);
       return Result;
     }

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -183,8 +183,8 @@ bool EbmlMaster::CheckMandatory() const
 
   for (unsigned int EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {
-      if (FindElt(EBML_CTX_IDX_INFO(MasterContext,EltIdx)) == nullptr) {
-        const auto & semcb = EBML_CTX_IDX(MasterContext,EltIdx).GetCallbacks();
+      const auto & semcb = EBML_CTX_IDX_INFO(MasterContext,EltIdx);
+      if (FindElt(semcb) == nullptr) {
         const bool hasDefaultValue = semcb.HasDefault();
 
 #if !defined(NDEBUG)

--- a/test/test_crc.cxx
+++ b/test/test_crc.cxx
@@ -33,7 +33,7 @@ int main(int /*argc*/, char** /*argv*/)
     if (ElementLevel0 == nullptr)
         return 1;
 
-    if (ElementLevel0->GetClassId() != libebml::EbmlHead::ClassId())
+    if (ElementLevel0->GetClassId() != EBML_ID(libebml::EbmlHead))
         return 1;
 
     libebml::EbmlHead &ReadHead = static_cast<libebml::EbmlHead &>(*ElementLevel0);

--- a/test/test_header.cxx
+++ b/test/test_header.cxx
@@ -34,7 +34,7 @@ int main(int /*argc*/, char** /*argv*/)
     if (ElementLevel0 == nullptr)
         return 1;
 
-    if (ElementLevel0->GetClassId() != libebml::EbmlHead::ClassId())
+    if (ElementLevel0->GetClassId() != EBML_ID(libebml::EbmlHead))
         return 1;
 
     libebml::EbmlHead &ReadHead = static_cast<libebml::EbmlHead &>(*ElementLevel0);


### PR DESCRIPTION
We can do with less methods and reuse the methods that already exist to do the same calls.

That will make things easier to maintain.