### PR TITLE
cmake: remove various warning suppressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,9 @@ if(DEV_MODE)
   message(STATUS "Using developer mode for ${CMAKE_CXX_COMPILER_ID}")
   set(CMAKE_CXX_EXTENSIONS OFF)
   add_cxx_flag_if_supported(-Wno-error=unused-command-line-argument
-                            -Wall -Wno-comment -Wfatal-errors -fstack-protector-strong -Wnon-virtual-dtor -Wextra
-                            -Wunused -Wpedantic -Woverloaded-virtual -Wshadow
-                            -Wno-self-assign -Wno-mismatched-tags -Wno-inconsistent-missing-override
-                            -Wno-potentially-evaluated-expression -Wno-extra-semi -Wno-gnu-zero-variadic-macro-arguments
+                            -Wall -Wextra -Wpedantic -Wfatal-errors -fstack-protector-strong
+                            -Wno-self-assign
                             -Wcast-align)
-  add_cxx_flag_if_supported(-Qunused-arguments)
 endif()
 
 set(libebml_SOURCES


### PR DESCRIPTION
Most of the have already been fixed.