### PR TITLE
Cleanup includes in public headers

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <string>
 #include <limits>
+#include <cstddef>
 
 namespace libebml {
 

--- a/ebml/EbmlEndian.h
+++ b/ebml/EbmlEndian.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <cstddef>
 
 #include "EbmlConfig.h" // contains _ENDIANESS_
 

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -8,6 +8,7 @@
 #ifndef LIBEBML_ID_H
 #define LIBEBML_ID_H
 
+#include <cstddef>
 #include "EbmlTypes.h"
 
 namespace libebml {

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -9,6 +9,7 @@
 #define LIBEBML_ID_H
 
 #include <cstddef>
+#include "EbmlConfig.h"
 #include "EbmlTypes.h"
 
 namespace libebml {

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -24,6 +24,4 @@ enum ScopeMode {
 
 } // namespace libebml
 
-#include "EbmlEndian.h" // binary needs to be defined
-
 #endif

--- a/ebml/EbmlTypes.h
+++ b/ebml/EbmlTypes.h
@@ -9,8 +9,6 @@
 
 #include <cstdint>
 
-#include "EbmlConfig.h"
-
 namespace libebml {
 
 using binary = std::uint8_t;

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <exception>
 #include <cstdio>
+#include <cstddef>
 // #include <iostream>
 
 

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -10,11 +10,7 @@
 #include "EbmlConfig.h"
 #include "EbmlTypes.h"
 
-#include <cassert>
-#include <exception>
 #include <cstdio>
-#include <cstddef>
-// #include <iostream>
 
 
 namespace libebml {

--- a/ebml/IOCallback.h
+++ b/ebml/IOCallback.h
@@ -7,6 +7,7 @@
 #ifndef MATROSKA_IOCALLBACK_H
 #define MATROSKA_IOCALLBACK_H
 
+#include "EbmlConfig.h"
 #include "EbmlTypes.h"
 
 #include <cassert>

--- a/ebml/SafeReadIOCallback.h
+++ b/ebml/SafeReadIOCallback.h
@@ -12,6 +12,7 @@
 #include "IOCallback.h"
 
 #include <memory>
+#include <exception>
 
 namespace libebml {
 

--- a/src/EbmlDate.cpp
+++ b/src/EbmlDate.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 
 #include "ebml/EbmlDate.h"
+#include "ebml/EbmlEndian.h"
 
 namespace libebml {
 

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 
 #include "ebml/EbmlFloat.h"
+#include "ebml/EbmlEndian.h"
 
 namespace libebml {
 

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -12,6 +12,8 @@
 
 #include "lib/utf8-cpp/source/utf8/checked.h"
 
+#include <cstring>
+
 namespace libebml {
 
 namespace {

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -8,6 +8,8 @@
 
 #include "ebml/MemIOCallback.h"
 
+#include <cstring>
+
 namespace libebml {
 
 MemIOCallback::MemIOCallback(std::uint64_t DefaultSize)

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <limits>
 #include <sstream>
+#include <cstring>
 
 #include "ebml/StdIOCallback.h"
 


### PR DESCRIPTION
Now `EbmlTypes.h` only defines libebml types. `EbmlEndian.h` is only included where it's used.