### PR TITLE
Use more standard exceptions and remove CRTError exception

### DIFF
--- a/ebml/StdIOCallback.h
+++ b/ebml/StdIOCallback.h
@@ -9,9 +9,6 @@
 
 #include "IOCallback.h"
 
-#include <stdexcept>
-#include <cerrno>
-
 namespace libebml {
 
 enum open_mode {
@@ -19,20 +16,6 @@ enum open_mode {
     MODE_WRITE,
     MODE_CREATE,
     MODE_SAFE
-};
-
-class EBML_DLL_API CRTError:public std::runtime_error
-{
-// Variablen...
-private:
-  int Error;
-
-// Methoden...
-public:
-  CRTError(int Error,const std::string&Description);
-  explicit CRTError(const std::string&Description,int Error=errno);
-
-  int getError() const noexcept { return Error; }
 };
 
 // This class is currently private to the library, so there's no MATROSKA_EXPORT.

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -7,9 +7,9 @@
   \author Julien Coloos  <suiryc @ users.sf.net>
 */
 #include <string>
+#include <stdexcept>
 
 #include "ebml/EbmlBinary.h"
-#include "ebml/StdIOCallback.h"
 
 namespace libebml {
 
@@ -85,7 +85,7 @@ filepos_t EbmlBinary::ReadData(IOCallback & input, ScopeMode ReadFully)
 
   Data = (GetSize() < std::numeric_limits<std::size_t>::max()) ? static_cast<binary *>(malloc(GetSize())) : nullptr;
   if (Data == nullptr)
-    throw CRTError(std::string("Error allocating data"));
+    throw std::runtime_error("Error allocating data");
   SetValueIsSet();
   return input.read(Data, GetSize());
 }

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <limits>
 #include <sstream>
+#include <ios>
 
 #include "ebml/StdIOCallback.h"
 
@@ -56,7 +57,7 @@ StdIOCallback::StdIOCallback(const char*Path, const open_mode aMode)
   if(File==nullptr) {
     stringstream Msg;
     Msg<<"Can't open stdio file \""<<Path<<"\" in mode \""<<Mode<<"\"";
-    throw CRTError(Msg.str());
+    throw ios_base::failure(Msg.str(), error_code{errno, std::system_category()});
   }
   mCurrentPosition = 0;
 }
@@ -90,7 +91,7 @@ void StdIOCallback::setFilePointer(std::int64_t Offset,seek_mode Mode)
   if(fseek(File,Offset,Mode)!=0) {
     ostringstream Msg;
     Msg<<"Failed to seek file "<<File<<" to offset "<<Offset<<" in mode "<<Mode;
-    throw CRTError(Msg.str());
+    throw ios_base::failure(Msg.str(), error_code{errno, std::system_category()});
   }
 
   switch ( Mode ) {
@@ -123,7 +124,7 @@ std::uint64_t StdIOCallback::getFilePointer()
   if(Result<0) {
     stringstream Msg;
     Msg<<"Can't tell the current file pointer position for "<<File;
-    throw CRTError(Msg.str());
+    throw ios_base::failure(Msg.str(), error_code{errno, std::system_category()});
   }
 #endif
 
@@ -138,7 +139,7 @@ void StdIOCallback::close()
   if(fclose(File)!=0) {
     stringstream Msg;
     Msg<<"Can't close file "<<File;
-    throw CRTError(Msg.str());
+    throw ios_base::failure(Msg.str(), error_code{errno, std::system_category()});
   }
 
   File=nullptr;

--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -18,19 +18,6 @@ using namespace std;
 
 namespace libebml {
 
-CRTError::CRTError(int nError, const std::string & Description)
-  :std::runtime_error(Description+": "+strerror(nError))
-  ,Error(nError)
-{
-}
-
-CRTError::CRTError(const std::string & Description,int nError)
-  :std::runtime_error(Description+": "+strerror(nError))
-  ,Error(nError)
-{
-}
-
-
 StdIOCallback::StdIOCallback(const char*Path, const open_mode aMode)
 {
   assert(Path!=nullptr);


### PR DESCRIPTION
It's not used explicitly in mkvtoolnix or VLC.