### PR TITLE
add missing filter checks in UpdateSize()

### DIFF
--- a/ebml/EbmlDate.h
+++ b/ebml/EbmlDate.h
@@ -46,7 +46,10 @@ class EBML_DLL_API EbmlDate : public EbmlElementDefaultSameStorage<std::int64_t>
     /*!
       \note no Default date handled
     */
-    filepos_t UpdateSize(const ShouldWrite & /* writeFilter */, bool /* bForceRender = false */) override {
+    filepos_t UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender = false */) override {
+      if (!CanWrite(writeFilter))
+        return 0;
+
       if(!ValueIsSet())
         SetSize_(0);
       else

--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -62,8 +62,11 @@ filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, c
 /*!
   \note no Default binary value handled
 */
-std::uint64_t EbmlBinary::UpdateSize(const ShouldWrite & /* writeFilter */, bool /* bForceRender */)
+std::uint64_t EbmlBinary::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
+  if (!CanWrite(writeFilter))
+    return 0;
+
   return GetSize();
 }
 

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -98,6 +98,9 @@ bool EbmlMaster::PushElement(EbmlElement & element)
 
 std::uint64_t EbmlMaster::UpdateSize(const ShouldWrite & writeFilter, bool bForceRender)
 {
+  if (!CanWrite(writeFilter))
+    return 0;
+
   SetSize_(0);
 
   if (!IsFiniteSize())


### PR DESCRIPTION
All filtered out elements should give a size of 0. The result is usually not used but the result should be consistent.

It's already done this way for most elements.