### PR TITLE
fix MemIOCallback IOCallback write return type

### DIFF
--- a/ebml/MemIOCallback.h
+++ b/ebml/MemIOCallback.h
@@ -69,7 +69,7 @@ public:
   /*!
     Use this to write some data from another IOCallback
   */
-  std::uint32_t write(IOCallback & IOToRead, std::size_t Size);
+  std::size_t write(IOCallback & IOToRead, std::size_t Size);
 
   bool IsOk() const { return mOk; }
   const std::string &GetLastErrorStr() const { return mLastErrorStr; }

--- a/src/MemIOCallback.cpp
+++ b/src/MemIOCallback.cpp
@@ -78,7 +78,7 @@ std::size_t MemIOCallback::write(const void *Buffer, std::size_t Size)
   return Size;
 }
 
-std::uint32_t MemIOCallback::write(IOCallback & IOToRead, std::size_t Size)
+std::size_t MemIOCallback::write(IOCallback & IOToRead, std::size_t Size)
 {
   if (dataBufferPos + Size < Size) // overflow, we can't hold that much
     return 0;


### PR DESCRIPTION
Missing from 701f7b2a290f4e8acbcd99a116a9c8a91d351de7.

That API seems to be unused.