### PR TITLE
make EbmlElement::HeadSize private 

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -509,6 +509,10 @@ class EBML_DLL_API EbmlElement {
       return ElementPosition;
     }
 
+    std::uint64_t GetDataStart() const {
+      return GetElementPosition() + HeadSize();
+    }
+
     std::uint64_t ElementSize(const ShouldWrite& writeFilter = WriteSkipDefault) const; /// return the size of the header+data, before writing
 
     filepos_t Render(IOCallback & output, const ShouldWrite& writeFilter = WriteSkipDefault, bool bKeepPosition = false, bool bForceRender = false);

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -532,10 +532,6 @@ class EBML_DLL_API EbmlElement {
     virtual bool IsDummy() const {return false;}
     virtual bool IsMaster() const {return false;}
 
-    std::size_t HeadSize() const {
-      return EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
-    } /// return the size of the head, on reading/writing
-
     /*!
       \brief Force the size of an element
       \warning only possible if the size is "undefined"
@@ -600,6 +596,10 @@ class EBML_DLL_API EbmlElement {
     const EbmlCallbacks & ClassInfo;
 
   private:
+    std::size_t HeadSize() const {
+      return EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
+    } /// return the size of the head, on reading/writing
+
     std::uint64_t Size;        ///< the size of the data to write
     std::uint64_t DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
     int SizeLength{0}; /// the minimum size on which the size will be written (0 = optimal)

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -48,10 +48,6 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
       return (0-1);
     }
 
-    std::uint64_t GetDataStart() const {
-      return GetElementPosition() + HeadSize();
-    }
-
     /*!
       \brief find the element corresponding to the ID of the element, NULL if not found
     */

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -37,11 +37,12 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, con
 std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, const ShouldWrite& writeFilter)
 {
   EltToReplaceWith.UpdateSize(writeFilter);
-  if (HeadSize() + GetSize() < EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize()) {
+  const auto EltSize = EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize();
+  if (HeadSize() + GetSize() < EltSize) {
     // the element can't be written here !
     return INVALID_FILEPOS_T;
   }
-  const std::size_t NewVoidSize = HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize();
+  const std::size_t NewVoidSize = HeadSize() + GetSize() - EltSize;
   if (NewVoidSize == EBML_ID_LENGTH(Id_EbmlVoid)) {
     // there is not enough space to put a filling element
     return INVALID_FILEPOS_T;
@@ -79,7 +80,8 @@ std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & ou
     // this element has never been written
     return 0;
   }
-  if (EltToVoid.GetSize() + EltToVoid.HeadSize() <2) {
+  const auto EltSize = EltToVoid.GetSize() + EltToVoid.HeadSize();
+  if (EltSize <2) {
     // the element can't be written here !
     return 0;
   }
@@ -89,12 +91,12 @@ std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & ou
   output.setFilePointer(EltToVoid.GetElementPosition());
 
   // compute the size of the voided data based on the original one
-  SetSize(EltToVoid.GetSize() + EltToVoid.HeadSize() - EBML_ID_LENGTH(Id_EbmlVoid));
+  SetSize(EltSize - EBML_ID_LENGTH(Id_EbmlVoid));
   SetSize(GetSize() - CodedSizeLength(GetSize(), GetSizeLength()));
   // make sure we handle even the strange cases
   //std::uint32_t A1 = GetSize() + HeadSize();
   //std::uint32_t A2 = EltToVoid.GetSize() + EltToVoid.HeadSize();
-  if (GetSize() + HeadSize() != EltToVoid.GetSize() + EltToVoid.HeadSize()) {
+  if (GetSize() + HeadSize() != EltSize) {
     SetSize(GetSize()-1);
     SetSizeLength(CodedSizeLength(GetSize(), GetSizeLength()) + 1);
   }
@@ -107,7 +109,7 @@ std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & ou
     output.setFilePointer(CurrentPosition);
   }
 
-  return EltToVoid.GetSize() + EltToVoid.HeadSize();
+  return EltSize;
 }
 
 } // namespace libebml

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -37,7 +37,7 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, con
 std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, const ShouldWrite& writeFilter)
 {
   EltToReplaceWith.UpdateSize(writeFilter);
-  const auto EltSize = EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize();
+  const auto EltSize = EltToReplaceWith.ElementSize(writeFilter);
   if (HeadSize() + GetSize() < EltSize) {
     // the element can't be written here !
     return INVALID_FILEPOS_T;

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -82,7 +82,7 @@ std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & ou
     // this element has never been written
     return 0;
   }
-  const auto EltSize = EltToVoid.GetSize() + EltToVoid.HeadSize();
+  const auto EltSize = EltToVoid.ElementSize([](const EbmlElement&){ return true; });
   if (EltSize <2) {
     // the element can't be written here !
     return 0;

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -72,13 +72,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   if (NewVoidSize != 0) {
     // fill the rest with another void element
     EbmlVoid aTmp;
-    aTmp.SetSize_(NewVoidSize - EBML_ID_LENGTH(Id_EbmlVoid));
-    const std::size_t HeadBefore = aTmp.HeadSize();
-    aTmp.SetSize_(aTmp.GetSize() - CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength()));
-    const std::size_t HeadAfter = aTmp.HeadSize();
-    if (HeadBefore != HeadAfter) {
-      aTmp.SetSizeLength(CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength()) - (HeadAfter - HeadBefore));
-    }
+    SetVoidSize(aTmp, NewVoidSize);
     aTmp.RenderHead(output, false, writeFilter); // the rest of the data is not rewritten
   }
 

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -42,7 +42,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
     return INVALID_FILEPOS_T;
   }
   const std::size_t NewVoidSize = HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize();
-  if (NewVoidSize == 1) {
+  if (NewVoidSize == EBML_ID_LENGTH(Id_EbmlVoid)) {
     // there is not enough space to put a filling element
     return INVALID_FILEPOS_T;
   }
@@ -52,10 +52,10 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   output.setFilePointer(GetElementPosition());
   EltToReplaceWith.Render(output, writeFilter);
 
-  if (NewVoidSize > 1) {
+  if (NewVoidSize > EBML_ID_LENGTH(Id_EbmlVoid)) {
     // fill the rest with another void element
     EbmlVoid aTmp;
-    aTmp.SetSize_(NewVoidSize - 1); // 1 is the length of the Void ID
+    aTmp.SetSize_(NewVoidSize - EBML_ID_LENGTH(Id_EbmlVoid));
     const std::size_t HeadBefore = aTmp.HeadSize();
     aTmp.SetSize_(aTmp.GetSize() - CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength()));
     const std::size_t HeadAfter = aTmp.HeadSize();
@@ -89,7 +89,7 @@ std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & ou
   output.setFilePointer(EltToVoid.GetElementPosition());
 
   // compute the size of the voided data based on the original one
-  SetSize(EltToVoid.GetSize() + EltToVoid.HeadSize() - 1); // 1 for the ID
+  SetSize(EltToVoid.GetSize() + EltToVoid.HeadSize() - EBML_ID_LENGTH(Id_EbmlVoid));
   SetSize(GetSize() - CodedSizeLength(GetSize(), GetSizeLength()));
   // make sure we handle even the strange cases
   //std::uint32_t A1 = GetSize() + HeadSize();

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -38,6 +38,8 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
 {
   EltToReplaceWith.UpdateSize(writeFilter);
   const auto EltSize = EltToReplaceWith.ElementSize(writeFilter);
+  if (EltSize == 0)
+    return INVALID_FILEPOS_T;
   if (HeadSize() + GetSize() < EltSize) {
     // the element can't be written here !
     return INVALID_FILEPOS_T;

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -40,11 +40,12 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   const auto EltSize = EltToReplaceWith.ElementSize(writeFilter);
   if (EltSize == 0)
     return INVALID_FILEPOS_T;
-  if (HeadSize() + GetSize() < EltSize) {
+  const auto CurrentVoidSize = ElementSize(writeFilter);
+  if (CurrentVoidSize < EltSize) {
     // the element can't be written here !
     return INVALID_FILEPOS_T;
   }
-  const std::size_t NewVoidSize = HeadSize() + GetSize() - EltSize;
+  const auto NewVoidSize = CurrentVoidSize - EltSize;
   if (NewVoidSize == EBML_ID_LENGTH(Id_EbmlVoid)) {
     // there is not enough space to put a filling element
     return INVALID_FILEPOS_T;

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -41,7 +41,8 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
     // the element can't be written here !
     return INVALID_FILEPOS_T;
   }
-  if (HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize() == 1) {
+  const std::size_t NewVoidSize = HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize();
+  if (NewVoidSize == 1) {
     // there is not enough space to put a filling element
     return INVALID_FILEPOS_T;
   }
@@ -51,10 +52,10 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   output.setFilePointer(GetElementPosition());
   EltToReplaceWith.Render(output, writeFilter);
 
-  if (HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize() > 1) {
+  if (NewVoidSize > 1) {
     // fill the rest with another void element
     EbmlVoid aTmp;
-    aTmp.SetSize_(HeadSize() + GetSize() - EltToReplaceWith.GetSize() - EltToReplaceWith.HeadSize() - 1); // 1 is the length of the Void ID
+    aTmp.SetSize_(NewVoidSize - 1); // 1 is the length of the Void ID
     const std::size_t HeadBefore = aTmp.HeadSize();
     aTmp.SetSize_(aTmp.GetSize() - CodedSizeLength(aTmp.GetSize(), aTmp.GetSizeLength()));
     const std::size_t HeadAfter = aTmp.HeadSize();
@@ -68,7 +69,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
     output.setFilePointer(CurrentPosition);
   }
 
-  return GetSize() + HeadSize();
+  return NewVoidSize;
 }
 
 std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, const ShouldWrite& writeFilter)

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -38,12 +38,14 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, con
 static void SetVoidSize(EbmlVoid & Elt, const std::uint64_t FullSize)
 {
   // compute the size of the voided data based on the original one
-  Elt.SetSize(FullSize - EBML_ID_LENGTH(Id_EbmlVoid));
-  Elt.SetSize(Elt.GetSize() - CodedSizeLength(Elt.GetSize(), Elt.GetSizeLength()));
+  const auto InitialSizeMinusID = FullSize - EBML_ID_LENGTH(Id_EbmlVoid);
+  const auto InitialSizeLength = Elt.GetSizeLength();
+  const auto DataSize = InitialSizeMinusID - CodedSizeLength(InitialSizeMinusID, InitialSizeLength);
+  Elt.SetSize(DataSize);
   // make sure we handle even the strange cases
-  if (Elt.GetSize() + Elt.HeadSize() != FullSize) {
-    Elt.SetSize(Elt.GetSize()-1);
-    Elt.SetSizeLength(CodedSizeLength(Elt.GetSize(), Elt.GetSizeLength()) + 1);
+  if (DataSize + EBML_ID_LENGTH(Id_EbmlVoid) + CodedSizeLength(DataSize, InitialSizeLength) != FullSize) {
+    Elt.SetSize(DataSize-1);
+    Elt.SetSizeLength(CodedSizeLength(DataSize, InitialSizeLength)  + 1);
   }
 }
 

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -52,7 +52,7 @@ std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback &
   output.setFilePointer(GetElementPosition());
   EltToReplaceWith.Render(output, writeFilter);
 
-  if (NewVoidSize > EBML_ID_LENGTH(Id_EbmlVoid)) {
+  if (NewVoidSize != 0) {
     // fill the rest with another void element
     EbmlVoid aTmp;
     aTmp.SetSize_(NewVoidSize - EBML_ID_LENGTH(Id_EbmlVoid));


### PR DESCRIPTION
The Head size is rarely needed and may be 0 depending on writing filter.

Draft on top of #255