### PR TITLE
disable most verbose warnings in MSVC in Dev Mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,8 @@ if(DEV_MODE)
   add_cxx_flag_if_supported(-Wno-error=unused-command-line-argument
                             -Wall -Wextra -Wpedantic -Wfatal-errors -fstack-protector-strong
                             -Wno-self-assign
-                            -Wcast-align)
+                            -Wcast-align
+                            -W4)
 endif()
 
 set(libebml_SOURCES


### PR DESCRIPTION
They are very noisy and not very useful.

the list of warnings can be found at https://learn.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default