### PR TITLE
drop CMake older than 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(ebml VERSION 2.0.0)
 


### PR DESCRIPTION
It generates a warning with newer versions of CMake. 3.4 was released in 2015. We require C++17 with compilers only available in 2017/2018. If your CMake is older than your toolchain, you have a problem.

There's no need to support legacy CMake going forward in libebml 2.