### PR TITLE
Don't export EbmlMaster context, use the class static member

### DIFF
--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -13,7 +13,7 @@
 
 namespace libebml {
 
-extern const EbmlSemanticContext EBML_DLL_API Context_EbmlHead;
+extern const EbmlSemanticContextMaster EBML_DLL_API Context_EbmlHead;
 
 // global elements
 extern const EbmlSemanticContext EBML_DLL_API & GetEbmlGlobal_Context();

--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -14,7 +14,7 @@
 
 namespace libebml {
 
-#define Context_EbmlHead   EBML_MASTER_CLASS_CONTEXT(EbmlHead)
+#define Context_EbmlHead   EBML_CLASS_CONTEXT(EbmlHead)
 
 // global elements
 extern const EbmlSemanticContextMaster EBML_DLL_API & GetEbmlGlobal_Context();

--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -14,7 +14,7 @@
 
 namespace libebml {
 
-#define Context_EbmlHead   EbmlHead::GetContextMaster()
+#define Context_EbmlHead   EBML_MASTER_CLASS_CONTEXT(EbmlHead)
 
 // global elements
 extern const EbmlSemanticContextMaster EBML_DLL_API & GetEbmlGlobal_Context();

--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -16,7 +16,7 @@ namespace libebml {
 extern const EbmlSemanticContextMaster EBML_DLL_API Context_EbmlHead;
 
 // global elements
-extern const EbmlSemanticContext EBML_DLL_API & GetEbmlGlobal_Context();
+extern const EbmlSemanticContextMaster EBML_DLL_API & GetEbmlGlobal_Context();
 
 } // namespace libebml
 

--- a/ebml/EbmlContexts.h
+++ b/ebml/EbmlContexts.h
@@ -10,10 +10,11 @@
 
 #include "EbmlTypes.h"
 #include "EbmlElement.h"
+#include "EbmlHead.h"
 
 namespace libebml {
 
-extern const EbmlSemanticContextMaster EBML_DLL_API Context_EbmlHead;
+#define Context_EbmlHead   EbmlHead::GetContextMaster()
 
 // global elements
 extern const EbmlSemanticContextMaster EBML_DLL_API & GetEbmlGlobal_Context();

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -64,20 +64,18 @@ class EbmlElement;
 // define a master class with a custom constructor
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    const libebml::EbmlSemanticContextMaster & x::GetContextMaster() { return Context_##x; } \
-    constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
+    const libebml::EbmlSemanticContextMaster x::SemanticContext = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, &parent::SemanticContext, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, x::SemanticContext, versions); \
 
 // define a master class with no parent class (can be used globally)
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
-    const libebml::EbmlSemanticContextMaster & x::GetContextMaster() { return Context_##x; } \
-    constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
+    const libebml::EbmlSemanticContextMaster x::SemanticContext = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, x::SemanticContext, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    static constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(&Context_##parent, global, &EBML_INFO(x));
+    static constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext( &parent::SemanticContext, global, &EBML_INFO(x));
 
 #define DEFINE_xxx_CLASS_BASE(x,BaseClass,id,parent,name,versions,global) \
     DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
@@ -194,7 +192,8 @@ class DllApi x : public BaseClass { \
 
 #define DECLARE_xxx_MASTER(x,DllApi)    \
   DECLARE_xxx_BASE_MASTER(x, DllApi, libebml::EbmlMaster) \
-  static const libebml::EbmlSemanticContextMaster & GetContextMaster();
+  static const libebml::EbmlSemanticContextMaster SemanticContext; \
+  static const libebml::EbmlSemanticContextMaster & GetContextMaster() { return SemanticContext; }
 
 #define DECLARE_xxx_BINARY(x,DllApi)    \
   DECLARE_xxx_BASE(x, DllApi, libebml::EbmlBinary)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -275,6 +275,8 @@ class DllApi x : public BaseClass { \
 #define EBML_CTX_IDX_INFO(c,i) EBML_SEM_SPECS(EBML_CTX_IDX(c,i))
 #define EBML_CTX_IDX_ID(c,i)   EBML_INFO_ID(EBML_CTX_IDX_INFO(c,i))
 
+#define EBML_MASTER_CLASS_CONTEXT(ref)    (EBML_INFO(ref)).GetContextMaster()
+
 #if !defined(INVALID_FILEPOS_T)
 #define INVALID_FILEPOS_T 0
 #endif

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -255,7 +255,6 @@ class DllApi x : public BaseClass { \
 #define EBML_INFO(ref)             ref::GetElementSpec()
 #define EBML_ID(ref)               EBML_INFO_ID(EBML_INFO(ref))
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
-#define EBML_CLASS_CONTEXT(ref)    EBML_INFO_CONTEXT(EBML_INFO(ref))
 #define EBML_CONTEXT(e)            tEBML_CONTEXT(e)
 #define EBML_NAME(e)               tEBML_NAME(e)
 
@@ -275,7 +274,7 @@ class DllApi x : public BaseClass { \
 #define EBML_CTX_IDX_INFO(c,i) EBML_SEM_SPECS(EBML_CTX_IDX(c,i))
 #define EBML_CTX_IDX_ID(c,i)   EBML_INFO_ID(EBML_CTX_IDX_INFO(c,i))
 
-#define EBML_MASTER_CLASS_CONTEXT(ref)    (EBML_INFO(ref)).GetContextMaster()
+#define EBML_CLASS_CONTEXT(ref)    (EBML_INFO(ref)).GetContextMaster()
 
 #if !defined(INVALID_FILEPOS_T)
 #define INVALID_FILEPOS_T 0

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -188,6 +188,7 @@ class DllApi x : public BaseClass { \
   private: \
     static const libebml::EbmlCallbacks ClassInfos; \
   public: \
+    static constexpr const libebml::EbmlCallbacks & GetElementSpec() { return ClassInfos; } \
     x();
 
 #define DECLARE_xxx_MASTER(x,DllApi)    \
@@ -251,7 +252,7 @@ class DllApi x : public BaseClass { \
     static libebml::EbmlElement & Create() {return *(new Type);} \
         static constexpr const libebml::EbmlCallbacks & ClassInfo() {return ClassInfos;} \
 
-#define EBML_INFO(ref)             ref::ClassInfo()
+#define EBML_INFO(ref)             ref::GetElementSpec()
 #define EBML_ID(ref)               EBML_INFO_ID(EBML_INFO(ref))
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
 #define EBML_CLASS_CONTEXT(ref)    EBML_INFO_CONTEXT(EBML_INFO(ref))

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -65,12 +65,14 @@ class EbmlElement;
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
+    const libebml::EbmlSemanticContextMaster & x::GetContextMaster() { return Context_##x; } \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 // define a master class with no parent class
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
+    const libebml::EbmlSemanticContextMaster & x::GetContextMaster() { return Context_##x; } \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
@@ -190,7 +192,8 @@ class DllApi x : public BaseClass { \
     x();
 
 #define DECLARE_xxx_MASTER(x,DllApi)    \
-  DECLARE_xxx_BASE_MASTER(x, DllApi, libebml::EbmlMaster)
+  DECLARE_xxx_BASE_MASTER(x, DllApi, libebml::EbmlMaster) \
+  static const libebml::EbmlSemanticContextMaster & GetContextMaster();
 
 #define DECLARE_xxx_BINARY(x,DllApi)    \
   DECLARE_xxx_BASE(x, DllApi, libebml::EbmlBinary)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -68,7 +68,7 @@ class EbmlElement;
     const libebml::EbmlSemanticContextMaster & x::GetContextMaster() { return Context_##x; } \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
-// define a master class with no parent class
+// define a master class with no parent class (can be used globally)
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
@@ -133,6 +133,7 @@ class EbmlElement;
 #define DEFINE_xxx_DATE_DEF(x,id,parent,name,versions,global,defval) \
     DEFINE_xxx_CLASS_BASE_DEFAULT(x,EbmlDate,id,parent,name,versions,global,defval, versions)
 
+// define a class with no parent class (can be used globally)
 #define DEFINE_xxx_CLASS_ORPHAN(x,id,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
     static constexpr const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(nullptr, global, nullptr); \

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -55,7 +55,7 @@ class EbmlSemanticContextMaster;
 class EbmlElement;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
-    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
+    constexpr const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
     DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
@@ -64,13 +64,13 @@ class EbmlElement;
 // define a master class with a custom constructor
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContextMaster x::SemanticContext = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, &parent::SemanticContext, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlSemanticContextMaster x::SemanticContext = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, &parent::SemanticContext, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, x::SemanticContext, versions); \
 
 // define a master class with no parent class (can be used globally)
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContextMaster x::SemanticContext = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
+    constexpr const libebml::EbmlSemanticContextMaster x::SemanticContext = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, x::SemanticContext, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -54,7 +54,7 @@ class EbmlSemanticContext;
 class EbmlElement;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
+    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
     DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
@@ -63,13 +63,13 @@ class EbmlElement;
 // define a master class with a custom constructor
 #define DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
+    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 // define a master class with no parent class
 #define DEFINE_xxx_MASTER_ORPHAN(x,id,infinite,name,versions,global) \
     static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
+    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, &EBML_INFO(x)); \
     constexpr const libebml::EbmlCallbacksMaster x::ClassInfos(x::Create, Id_##x, infinite, name, Context_##x, versions); \
 
 #define DEFINE_xxx_CLASS_CONS(x,id,parent,name,global) \
@@ -499,13 +499,28 @@ static inline const EbmlSemantic & tEBML_CTX_IDX(const EbmlSemanticContext & c, 
   return c.GetSemantic(i);
 }
 
+class EBML_DLL_API EbmlSemanticContextMaster : public EbmlSemanticContext {
+  public:
+    constexpr EbmlSemanticContextMaster(std::size_t aSize,
+      const EbmlSemantic *aMyTable,
+      const EbmlSemanticContext *aUpTable,
+      const _GetSemanticContext aGetGlobalContext,
+      const EbmlCallbacks *aMasterElt)
+      : EbmlSemanticContext(aSize, aMyTable, aUpTable, aGetGlobalContext, aMasterElt)
+    {}
+};
+
 class EBML_DLL_API EbmlCallbacksMaster : public EbmlCallbacks {
   public:
     constexpr EbmlCallbacksMaster(EbmlElement & (*Creator)(), const EbmlId & aGlobalId, bool aCanInfinite,
-                                  const char * aDebugName, const EbmlSemanticContext & aContext,
+                                  const char * aDebugName, const EbmlSemanticContextMaster & aContext,
                                   const EbmlDocVersion & aVersion)
       :EbmlCallbacks(Creator, aGlobalId, aCanInfinite, false, aDebugName, aContext, aVersion)
     {
+    }
+
+    inline constexpr const EbmlSemanticContextMaster & GetContextMaster() const {
+      return static_cast<const EbmlSemanticContextMaster &>(GetContext());
     }
 };
 

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -57,9 +57,7 @@ class EbmlElement;
     const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
-    static constexpr const libebml::EbmlId Id_##x    {id}; static_assert(libebml::EbmlId::IsValid(Id_##x .GetValue()), "invalid id for " name ); \
-    const libebml::EbmlSemanticContext Context_##x = libebml::EbmlSemanticContext(countof(ContextList_##x), ContextList_##x, &Context_##parent, global, &EBML_INFO(x)); \
-    constexpr const libebml::EbmlCallbacks x::ClassInfos(x::Create, Id_##x, infinite, false, name, Context_##x, versions); \
+    DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \
     x::x() :libebml::EbmlMaster(x::ClassInfos) {}
 
 // define a master class with a custom constructor

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -51,6 +51,7 @@ std::uint64_t EBML_DLL_API ReadCodedSizeValue(const binary * InBuffer, std::uint
 
 class EbmlStream;
 class EbmlSemanticContext;
+class EbmlSemanticContextMaster;
 class EbmlElement;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
@@ -442,7 +443,7 @@ static inline EbmlElement & tEBML_SEM_CREATE(const EbmlSemantic & s)
   return s.Create();
 }
 
-using _GetSemanticContext = const EbmlSemanticContext &(*)();
+using _GetSemanticContext = const EbmlSemanticContextMaster &(*)();
 
 /*!
   Context of the element

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -28,7 +28,7 @@ constexpr const bool bChecksumUsedByDefault = false;
 */
 class EBML_DLL_API EbmlMaster : public EbmlElement {
   public:
-    explicit EbmlMaster(const EbmlCallbacks &, bool bSizeIsKnown = true);
+    explicit EbmlMaster(const EbmlCallbacksMaster &, bool bSizeIsKnown = true);
     EbmlMaster(const EbmlMaster & ElementToClone);
     EbmlMaster& operator=(const EbmlMaster&) = delete;
     bool SizeIsValid(std::uint64_t /*size*/) const override {return true;}

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -151,6 +151,11 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     bool ProcessMandatory();
 };
 
+static inline constexpr const EbmlSemanticContextMaster & tEBML_CONTEXT(const EbmlMaster * e)
+{
+  return e->ContextMaster();
+}
+
 ///< \todo add a restriction to only elements legal in the context
 template <typename Type>
 Type & GetChild(EbmlMaster & Master)

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -156,6 +156,11 @@ static inline constexpr const EbmlSemanticContextMaster & tEBML_CONTEXT(const Eb
   return e->ContextMaster();
 }
 
+static inline constexpr const EbmlSemanticContextMaster & tEBML_INFO_CONTEXT(const EbmlCallbacksMaster & cb)
+{
+  return cb.GetContextMaster();
+}
+
 ///< \todo add a restriction to only elements legal in the context
 template <typename Type>
 Type & GetChild(EbmlMaster & Master)

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -37,6 +37,11 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     */
     ~EbmlMaster() override;
 
+    constexpr const EbmlSemanticContextMaster & ContextMaster() const
+    {
+      return static_cast<const EbmlSemanticContextMaster &>(Context());
+    }
+
     filepos_t RenderData(IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully) override;
     filepos_t UpdateSize(const ShouldWrite & writeFilter = WriteSkipDefault, bool bForceRender = false) override;

--- a/src/EbmlContexts.cpp
+++ b/src/EbmlContexts.cpp
@@ -18,7 +18,7 @@ DEFINE_END_SEMANTIC(EbmlGlobal)
 
 static DEFINE_xxx_CONTEXT(EbmlGlobal, GetEbmlGlobal_Context)
 
-const EbmlSemanticContext & GetEbmlGlobal_Context()
+const EbmlSemanticContextMaster & GetEbmlGlobal_Context()
 {
   return Context_EbmlGlobal;
 }

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -377,14 +377,14 @@ EbmlElement * EbmlElement::SkipData(EbmlStream & DataStream, const EbmlSemanticC
         // data known in this Master's context
         if (EBML_CTX_SIZE(Context))
         {
-        const auto & MasterContext = static_cast<const EbmlSemanticContextMaster &>(Context);
-        for (EltIndex = 0; EltIndex < EBML_CTX_SIZE(MasterContext); EltIndex++) {
-          if (EbmlId(*Result) == EBML_CTX_IDX_ID(MasterContext,EltIndex)) {
-            // skip the data with its own context
-            Result = Result->SkipData(DataStream, EBML_SEM_CONTEXT(EBML_CTX_IDX(MasterContext,EltIndex)), nullptr);
-            break; // let's go to the next ID
+          const auto & MasterContext = static_cast<const EbmlSemanticContextMaster &>(Context);
+          for (EltIndex = 0; EltIndex < EBML_CTX_SIZE(MasterContext); EltIndex++) {
+            if (EbmlId(*Result) == EBML_CTX_IDX_ID(MasterContext,EltIndex)) {
+              // skip the data with its own context
+              Result = Result->SkipData(DataStream, EBML_SEM_CONTEXT(EBML_CTX_IDX(MasterContext,EltIndex)), nullptr);
+              break; // let's go to the next ID
+            }
           }
-        }
         }
 
         if (EltIndex >= EBML_CTX_SIZE(Context)) {
@@ -417,16 +417,16 @@ EbmlElement *EbmlElement::CreateElementUsingContext(const EbmlId & aID, const Eb
   // elements at the current level
   if (EBML_CTX_SIZE(Context))
   {
-  const auto & MasterContext = static_cast<const EbmlSemanticContextMaster &>(Context);
-  for (unsigned int ContextIndex = 0; ContextIndex < EBML_CTX_SIZE(MasterContext); ContextIndex++) {
-    if (aID == EBML_CTX_IDX_ID(MasterContext,ContextIndex)) {
-      if (AsInfiniteSize && !EBML_CTX_IDX_INFO(MasterContext,ContextIndex).CanHaveInfiniteSize())
-        return nullptr;
-      Result = &EBML_SEM_CREATE(EBML_CTX_IDX(MasterContext,ContextIndex));
-      Result->SetSizeInfinite(AsInfiniteSize);
-      return Result;
+    const auto & MasterContext = static_cast<const EbmlSemanticContextMaster &>(Context);
+    for (unsigned int ContextIndex = 0; ContextIndex < EBML_CTX_SIZE(MasterContext); ContextIndex++) {
+      if (aID == EBML_CTX_IDX_ID(MasterContext,ContextIndex)) {
+        if (AsInfiniteSize && !EBML_CTX_IDX_INFO(MasterContext,ContextIndex).CanHaveInfiniteSize())
+          return nullptr;
+        Result = &EBML_SEM_CREATE(EBML_CTX_IDX(MasterContext,ContextIndex));
+        Result->SetSizeInfinite(AsInfiniteSize);
+        return Result;
+      }
     }
-  }
   }
 
   // global elements

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -15,7 +15,7 @@
 
 namespace libebml {
 
-EbmlMaster::EbmlMaster(const EbmlCallbacks & classInfo, bool bSizeIsknown)
+EbmlMaster::EbmlMaster(const EbmlCallbacksMaster & classInfo, bool bSizeIsknown)
  :EbmlElement(classInfo, 0)
 {
   SetSizeInfinite(!bSizeIsknown);

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -6,12 +6,13 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 
-#include <cassert>
-#include <algorithm>
-
 #include "ebml/EbmlMaster.h"
 #include "ebml/EbmlStream.h"
 #include "ebml/MemIOCallback.h"
+
+#include <cassert>
+#include <algorithm>
+#include <sstream>
 
 namespace libebml {
 
@@ -41,6 +42,18 @@ EbmlMaster::~EbmlMaster()
     delete Element;
   }
 }
+
+const EbmlSemantic & EbmlSemanticContextMaster::GetSemantic(std::size_t i) const
+{
+  assert(i<GetSize());
+  if (i<GetSize())
+    return MyTable[i];
+
+  std::stringstream ss;
+  ss << "EbmlSemanticContext::GetSemantic: programming error: index i outside of table size (" << i << " >= " << GetSize() << ")";
+  throw std::logic_error(ss.str());
+}
+
 
 /*!
   \todo handle exception on errors
@@ -153,7 +166,7 @@ filepos_t EbmlMaster::ReadData(IOCallback & input, ScopeMode scope)
 */
 bool EbmlMaster::ProcessMandatory()
 {
-  const EbmlSemanticContext & MasterContext = EBML_CONTEXT(this);
+  const auto & MasterContext = ContextMaster();
 
   for (unsigned int EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory() && EBML_CTX_IDX(MasterContext,EltIdx).IsUnique()) {
@@ -179,7 +192,7 @@ bool EbmlMaster::ProcessMandatory()
 
 bool EbmlMaster::CheckMandatory() const
 {
-  const EbmlSemanticContext & MasterContext = EBML_CONTEXT(this);
+  const auto & MasterContext = ContextMaster();
 
   for (unsigned int EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -2,6 +2,7 @@
 #include <ebml/EbmlString.h>
 #include <ebml/EbmlUInteger.h>
 #include <ebml/EbmlUnicodeString.h>
+#include <ebml/EbmlHead.h>
 
 using namespace libebml;
 

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -146,7 +146,7 @@ int main(void)
         return 1;
 
     [[maybe_unused]] const EbmlSemanticContext &ctx = EBML_CLASS_CONTEXT(EbmlHead);
-    [[maybe_unused]] const EbmlSemanticContextMaster &ctxMaster =  EBML_MASTER_CLASS_CONTEXT(EbmlHead);
+    [[maybe_unused]] const EbmlSemanticContextMaster &ctxMaster = EBML_CLASS_CONTEXT(EbmlHead);
 
     return 0;
 }

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -147,6 +147,10 @@ int main(void)
 
     [[maybe_unused]] const EbmlSemanticContext &ctx = EBML_CLASS_CONTEXT(EbmlHead);
     [[maybe_unused]] const EbmlSemanticContextMaster &ctxMaster = EBML_CLASS_CONTEXT(EbmlHead);
+    EbmlHead TestHead;
+    [[maybe_unused]] const EbmlSemanticContextMaster & MasterContext = EBML_CONTEXT(&TestHead);
+    [[maybe_unused]] const EbmlSemanticContext & BasicContext = EBML_CONTEXT(&TestHead);
+    [[maybe_unused]] const auto & AutoContext = EBML_CONTEXT(&TestHead);
 
     return 0;
 }

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -145,5 +145,8 @@ int main(void)
     if (genericnodef.IsDefaultValue())
         return 1;
 
+    [[maybe_unused]] const EbmlSemanticContext &ctx = EBML_CLASS_CONTEXT(EbmlHead);
+    [[maybe_unused]] const EbmlSemanticContextMaster &ctxMaster =  EBML_MASTER_CLASS_CONTEXT(EbmlHead);
+
     return 0;
 }

--- a/test/test_missing.cxx
+++ b/test/test_missing.cxx
@@ -10,7 +10,7 @@ using namespace libebml;
 
 static void FindAllMissingElements(const EbmlMaster *pThis, std::vector<std::string> & missingElements)
 {
-  const EbmlSemanticContext & MasterContext = EBML_CONTEXT(pThis);
+  const auto & MasterContext = pThis->ContextMaster();
   for (auto childElement : pThis->GetElementList()) {
     if (!childElement->ValueIsSet()) {
       std::string missingValue;
@@ -48,7 +48,7 @@ static void FindAllMissingElements(const EbmlMaster *pThis, std::vector<std::str
 int main(void)
 {
     EbmlHead TestHead;
-    const EbmlSemanticContext & MasterContext = EBML_CONTEXT(&TestHead);
+    const EbmlSemanticContextMaster & MasterContext = TestHead.ContextMaster();
 
     assert(MasterContext.GetSize() != 0);
 

--- a/test/test_missing.cxx
+++ b/test/test_missing.cxx
@@ -55,5 +55,8 @@ int main(void)
     std::vector<std::string> missingElements;
     FindAllMissingElements(&TestHead, missingElements);
 
+    const auto & tstStatic = EbmlHead::GetContextMaster();
+    assert(EBML_CTX_SIZE(tstStatic) != 0);
+
     return 0;
 }


### PR DESCRIPTION
The internal are reworked so only semantic context of EbmlMaster elements have a table of possible children.

"[Get]ElementSpec()" is generalized so there's stronger typing of the semantic context for all the types.

The callback to get the global elements now returns a `EbmlSemanticContextMaster`. Ultimately it only needs to return a container with a list of semantic context. 