### PR TITLE
don't capture anything while looking for a CRC32 element

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -406,7 +406,7 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
 processCrc:
 
   auto CrcItr =
-      std::find_if(ElementList.begin(), ElementList.end(), [=](auto &&element) {
+      std::find_if(ElementList.begin(), ElementList.end(), [](auto &&element) {
         return EbmlId(*element) == EBML_ID(EbmlCrc32);
       });
   if (CrcItr != ElementList.end()) {


### PR DESCRIPTION
`test_crc` still passes after this.