### PR TITLE
fix UpdateSize return type

### DIFF
--- a/src/EbmlBinary.cpp
+++ b/src/EbmlBinary.cpp
@@ -62,7 +62,7 @@ filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, c
 /*!
   \note no Default binary value handled
 */
-std::uint64_t EbmlBinary::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
+filepos_t EbmlBinary::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -489,7 +489,7 @@ filepos_t EbmlElement::Render(IOCallback & output, const ShouldWrite& writeFilte
     return 0;
   }
 #if !defined(NDEBUG)
-  std::uint64_t SupposedSize = UpdateSize(writeFilter, bForceRender);
+  filepos_t SupposedSize = UpdateSize(writeFilter, bForceRender);
 #endif // !NDEBUG
   filepos_t result = RenderHead(output, bForceRender, writeFilter, bKeepPosition);
   const std::uint64_t WrittenSize = RenderData(output, bForceRender, writeFilter);

--- a/src/EbmlFloat.cpp
+++ b/src/EbmlFloat.cpp
@@ -54,7 +54,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, co
   return GetSize();
 }
 
-std::uint64_t EbmlFloat::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
+filepos_t EbmlFloat::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -96,7 +96,7 @@ bool EbmlMaster::PushElement(EbmlElement & element)
   return false;
 }
 
-std::uint64_t EbmlMaster::UpdateSize(const ShouldWrite & writeFilter, bool bForceRender)
+filepos_t EbmlMaster::UpdateSize(const ShouldWrite & writeFilter, bool bForceRender)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlSInteger.cpp
+++ b/src/EbmlSInteger.cpp
@@ -65,7 +65,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-std::uint64_t EbmlSInteger::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
+filepos_t EbmlSInteger::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlString.cpp
+++ b/src/EbmlString.cpp
@@ -39,7 +39,7 @@ filepos_t EbmlString::RenderData(IOCallback & output, bool /* bForceRender */, c
   return Result;
 }
 
-std::uint64_t EbmlString::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
+filepos_t EbmlString::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlUInteger.cpp
+++ b/src/EbmlUInteger.cpp
@@ -48,7 +48,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
   return GetSize();
 }
 
-std::uint64_t EbmlUInteger::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
+filepos_t EbmlUInteger::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;

--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -144,7 +144,7 @@ std::string EbmlUnicodeString::GetValueUTF8() const {
 /*!
 \note limited to UCS-2
 */
-std::uint64_t EbmlUnicodeString::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
+filepos_t EbmlUnicodeString::UpdateSize(const ShouldWrite & writeFilter, bool /* bForceRender */)
 {
   if (!CanWrite(writeFilter))
     return 0;


### PR DESCRIPTION
Although filepos_t is a std::uint64_t it's better to use the proper type.