### PR TITLE
add a "namespace" to the EbmlDocVersion

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -275,9 +275,10 @@ class EBML_DLL_API EbmlDocVersion {
     //
     // \param min the minimum supported version, or ANY_VERSION to make the element never available
     // \param max the maximum supported version, 0 to make the element never available or ANY_VERSION to be supported on any known and unknown doctype version
-    constexpr EbmlDocVersion(version_type min = 0, version_type max = ANY_VERSION)
+    constexpr EbmlDocVersion(const std::string_view &name_space, version_type min = 0, version_type max = ANY_VERSION)
       : minver(min)
       , maxver(max)
+      , ns(name_space)
     {}
 
     // the element with this EbmlDocVersion should never be used if this methods return true
@@ -302,6 +303,8 @@ class EBML_DLL_API EbmlDocVersion {
     // ANY_VERSION if the element is supported in all (known) version
     version_type GetMaxVersion() const { return maxver; }
 
+    constexpr const std::string_view & GetNameSpace() const { return ns; }
+
     /// @brief constant value to indicate the maximum version matches all versions or the minimum version matches no version
     static const version_type ANY_VERSION = std::numeric_limits<version_type>::max();
 
@@ -312,6 +315,8 @@ class EBML_DLL_API EbmlDocVersion {
     // the maximum DocType version this element is allowed in
     // ANY_VERSION if the element is supported in all (known) version
     const version_type maxver;
+
+    const std::string_view ns;
 };
 
 // functions for generic handling of data (should be static to all classes)

--- a/src/EbmlCrc32.cpp
+++ b/src/EbmlCrc32.cpp
@@ -25,7 +25,7 @@ static constexpr std::uint32_t CRC32_NEGL = 0xffffffffL;
 
 namespace libebml {
 
-static constexpr EbmlDocVersion AllEbmlVersions{};
+static constexpr EbmlDocVersion AllEbmlVersions{"ebml"};
 
 DEFINE_EBML_CLASS_ORPHAN(EbmlCrc32, 0xBF, "EBMLCrc32", AllEbmlVersions)
 

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-static constexpr EbmlDocVersion AllEbmlVersions{};
+static constexpr EbmlDocVersion AllEbmlVersions{"ebml"};
 
 DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", AllEbmlVersions )
 

--- a/src/EbmlHead.cpp
+++ b/src/EbmlHead.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-static constexpr EbmlDocVersion AllEbmlVersions{};
+static constexpr EbmlDocVersion AllEbmlVersions{"ebml"};
 
 DEFINE_EBML_UINTEGER_DEF(EVersion,            0x4286, EbmlHead, "EBMLVersion", 1, AllEbmlVersions)
 DEFINE_EBML_UINTEGER_DEF(EReadVersion,        0x42F7, EbmlHead, "EBMLReadVersion", 1, AllEbmlVersions)

--- a/src/EbmlVoid.cpp
+++ b/src/EbmlVoid.cpp
@@ -10,7 +10,7 @@
 
 namespace libebml {
 
-static constexpr EbmlDocVersion AllEbmlVersions{};
+static constexpr EbmlDocVersion AllEbmlVersions{"ebml"};
 
 DEFINE_EBML_CLASS_ORPHAN(EbmlVoid, 0xEC, "EBMLVoid", AllEbmlVersions)
 
@@ -46,7 +46,7 @@ static void SetVoidSize(EbmlVoid & Elt, const std::uint64_t FullSize)
   if (EBML_ID_LENGTH(Id_EbmlVoid) + NewSizeLength + NewDataLength < FullSize)
   {
     // the computed size is too small,
-    // the Size length can be expanded, update the size Length which doesn't imply 
+    // the Size length can be expanded, update the size Length which doesn't imply
     // recomputing the whole size again
     NewSizeLength = static_cast<decltype(NewSizeLength)>(FullSize - (NewDataLength + EBML_ID_LENGTH(Id_EbmlVoid)));
   }

--- a/test/test_infinite.cxx
+++ b/test/test_infinite.cxx
@@ -7,7 +7,7 @@
 
 using namespace libebml;
 
-static constexpr EbmlDocVersion AllVersions{};
+static constexpr EbmlDocVersion AllVersions{"test_infinite"};
 
 DECLARE_xxx_UINTEGER_DEF(DummyChild,)
 EBML_CONCRETE_CLASS(DummyChild)

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -5,7 +5,7 @@
 
 using namespace libebml;
 
-static constexpr EbmlDocVersion AllVersions{};
+static constexpr EbmlDocVersion AllVersions{"test_macros"};
 
 DECLARE_EBML_STRING_DEF(StringWithDefault)
     EBML_CONCRETE_CLASS(StringWithDefault)


### PR DESCRIPTION
Otherwise we can differentiate with subclasses between EBML elements and Matroska elements which use a different EbmlDocVersion type. We can't tell between one or the other.