### PR TITLE
remove deprecated EbmlCodeDate string

### DIFF
--- a/ebml/EbmlVersion.h
+++ b/ebml/EbmlVersion.h
@@ -17,7 +17,6 @@ namespace libebml {
 #define LIBEBML_VERSION 0x020000
 
 extern const EBML_DLL_API std::string EbmlCodeVersion;
-extern const EBML_DLL_API std::string EbmlCodeDate;
 
 /*!
   \todo Closer relation between an element and the context it comes from (context is an element attribute ?)

--- a/src/EbmlVersion.cpp
+++ b/src/EbmlVersion.cpp
@@ -12,9 +12,4 @@ namespace libebml {
 
 const std::string EbmlCodeVersion = "2.0.0";
 
-// Up to version 1.3.3 this library exported a build date string. As
-// this made the build non-reproducible, replace it by a placeholder to
-// remain API compatible.
-const std::string EbmlCodeDate = "Unknown";
-
 } // namespace libebml


### PR DESCRIPTION
Unused except in a libmatroska test that is removed in https://github.com/Matroska-Org/libmatroska/pull/192