### PR TITLE
Rework element creation

### DIFF
--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -24,7 +24,6 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
       return DummyId;
     }
 
-    EbmlElement & CreateElement() const override { return Create(); }
     EbmlElement * Clone() const override { return new EbmlDummy(DummyId); }
 
     static EbmlElement & Create() { return *(new EbmlDummy()); }

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -257,6 +257,7 @@ class DllApi x : public BaseClass { \
 #define EBML_CONTEXT(e)            tEBML_CONTEXT(e)
 #define EBML_NAME(e)               tEBML_NAME(e)
 #define EBML_SPEC(e)               tEBML_SPEC(e)
+#define EBML_CREATE(e)             EBML_INFO_CREATE(EBML_SPEC(e))
 
 #define EBML_INFO_ID(cb)      tEBML_INFO_ID(cb)
 #define EBML_INFO_NAME(cb)    tEBML_INFO_NAME(cb)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -428,7 +428,6 @@ class EBML_DLL_API EbmlSemantic {
 
         inline constexpr bool IsMandatory() const { return Mandatory; }
         inline constexpr bool IsUnique() const { return Unique; }
-        inline EbmlElement & Create() const { return EBML_INFO_CREATE(Callbacks); }
         inline constexpr EbmlCallbacks const &GetCallbacks() const { return Callbacks; }
 
     private:

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -264,7 +264,7 @@ class DllApi x : public BaseClass { \
 
 #define EBML_SEM_SPECS(s)   tEBML_SEM_SPECS(s)
 #define EBML_SEM_CONTEXT(s) EBML_INFO_CONTEXT(EBML_SEM_SPECS(s))
-#define EBML_SEM_CREATE(s)  tEBML_SEM_CREATE(s)
+#define EBML_SEM_CREATE(s)  EBML_INFO_CREATE(EBML_SEM_SPECS(s))
 
 #define EBML_CTX_SIZE(c)       tEBML_CTX_SIZE(c)
 #define EBML_CTX_MASTER(c)     tEBML_CTX_MASTER(c)
@@ -440,11 +440,6 @@ class EBML_DLL_API EbmlSemantic {
 static inline constexpr const EbmlCallbacks & tEBML_SEM_SPECS(const EbmlSemantic & s)
 {
   return s.GetCallbacks();
-}
-
-static inline EbmlElement & tEBML_SEM_CREATE(const EbmlSemantic & s)
-{
-  return s.Create();
 }
 
 using _GetSemanticContext = const EbmlSemanticContextMaster &(*)();

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -247,7 +247,6 @@ class DllApi x : public BaseClass { \
 
 #define EBML_CONCRETE_CLASS(Type) \
     public: \
-        libebml::EbmlElement & CreateElement() const override {return Create();} \
         libebml::EbmlElement * Clone() const override { return new Type(*this); } \
     static libebml::EbmlElement & Create() {return *(new Type);} \
         static constexpr const libebml::EbmlCallbacks & ClassInfo() {return ClassInfos;} \
@@ -601,7 +600,7 @@ class EBML_DLL_API EbmlElement {
     virtual explicit operator const EbmlId &() const { return GetClassId(); }
     constexpr const char *DebugName() const {return ClassInfo.GetName();}
     constexpr const EbmlSemanticContext &Context() const {return ClassInfo.GetContext();}
-        virtual EbmlElement & CreateElement() const = 0;
+    EbmlElement & CreateElement() const { return EBML_INFO_CREATE(ClassInfo); }
 
     /*!
      * \brief Set whether the size is finite

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -256,6 +256,7 @@ class DllApi x : public BaseClass { \
 #define EBML_CLASS_SEMCONTEXT(ref) Context_##ref
 #define EBML_CONTEXT(e)            tEBML_CONTEXT(e)
 #define EBML_NAME(e)               tEBML_NAME(e)
+#define EBML_SPEC(e)               tEBML_SPEC(e)
 
 #define EBML_INFO_ID(cb)      tEBML_INFO_ID(cb)
 #define EBML_INFO_NAME(cb)    tEBML_INFO_NAME(cb)
@@ -817,6 +818,11 @@ class EBML_DLL_API EbmlElementDefaultStorage : public EbmlElementDefault<T> {
 static inline constexpr const EbmlSemanticContext & tEBML_CONTEXT(const EbmlElement * e)
 {
   return e->Context();
+}
+
+static inline const EbmlCallbacks & tEBML_SPEC(const EbmlElement & e)
+{
+  return e.ElementSpec();
 }
 
 static inline constexpr const char * tEBML_NAME(const EbmlElement * e)


### PR DESCRIPTION
To create a bare EbmlElement we don't need an actual element as in CreateElement(). We just need an EbmlCallbacks which may or may not come from an element.

For now `CreateElement()` is kept for backward compatibility but it can be replaced by an `EBML_CREATE()` call, which can call `CreateElement()` when compiled with libebml 1.x.