### PR TITLE
Make more use of typed children macros and remove FindElt

### DIFF
--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -49,14 +49,13 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
     }
 
     /*!
-      \brief find the element corresponding to the ID of the element, NULL if not found
+      \brief find the first element corresponding to the EBML class of the element, NULL if not found
     */
-    EbmlElement *FindElt(const EbmlCallbacks & Callbacks) const;
+    EbmlElement *FindFirstElt(const EbmlCallbacks & Callbacks) const;
     /*!
-      \brief find the first element corresponding to the ID of the element
+      \brief find the first element corresponding to the EBML class of the element
     */
     EbmlElement *FindFirstElt(const EbmlCallbacks & Callbacks, bool bCreateIfNull);
-    EbmlElement *FindFirstElt(const EbmlCallbacks & Callbacks) const;
 
     /*!
       \brief find the element of the same type of PasElt following in the list of elements

--- a/ebml/EbmlMaster.h
+++ b/ebml/EbmlMaster.h
@@ -156,9 +156,9 @@ Type & GetChild(EbmlMaster & Master)
 // MyDocType = GetChild<EDocType>(TestHead);
 
 template <typename Type>
-Type * FindChild(EbmlMaster & Master)
+Type * FindChild(const EbmlMaster & Master)
 {
-  return static_cast<Type *>(Master.FindFirstElt(EBML_INFO(Type), false));
+  return static_cast<Type *>(Master.FindFirstElt(EBML_INFO(Type)));
 }
 
 template <typename Type>
@@ -168,9 +168,9 @@ Type & GetNextChild(EbmlMaster & Master, const Type & PastElt)
 }
 
 template <typename Type>
-Type * FindNextChild(EbmlMaster & Master, const Type & PastElt)
+Type * FindNextChild(const EbmlMaster & Master, const Type & PastElt)
 {
-  return static_cast<Type *>(Master.FindNextElt(PastElt, false));
+  return static_cast<Type *>(Master.FindNextElt(PastElt));
 }
 
 template <typename Type>

--- a/ebml/EbmlStream.h
+++ b/ebml/EbmlStream.h
@@ -27,6 +27,12 @@ class EBML_DLL_API EbmlStream {
     */
     EbmlElement * FindNextID(const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize) const;
 
+    template <typename Type>
+    Type * FindNextID(std::uint64_t MaxDataSize)
+    {
+      return static_cast<Type *>(FindNextID(EBML_INFO(Type), MaxDataSize));
+    }
+
     EbmlElement * FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1) const;
 
     inline IOCallback & I_O() {return Stream;}

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -184,7 +184,7 @@ bool EbmlMaster::CheckMandatory() const
   for (unsigned int EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {
       const auto & semcb = EBML_CTX_IDX_INFO(MasterContext,EltIdx);
-      if (FindElt(semcb) == nullptr) {
+      if (FindFirstElt(semcb) == nullptr) {
         const bool hasDefaultValue = semcb.HasDefault();
 
 #if !defined(NDEBUG)
@@ -200,7 +200,7 @@ bool EbmlMaster::CheckMandatory() const
   return true;
 }
 
-EbmlElement *EbmlMaster::FindElt(const EbmlCallbacks & Callbacks) const
+EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
 {
   auto it = std::find_if(ElementList.begin(), ElementList.end(), [&](const EbmlElement *Element)
     { return EbmlId(*Element) == EBML_INFO_ID(Callbacks); });
@@ -210,7 +210,7 @@ EbmlElement *EbmlMaster::FindElt(const EbmlCallbacks & Callbacks) const
 
 EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCreateIfNull)
 {
-  auto e = FindElt(Callbacks);
+  auto e = FindFirstElt(Callbacks);
   if (e)
     return e;
 
@@ -220,11 +220,6 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCre
   }
 
   return nullptr;
-}
-
-EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
-{
-  return FindElt(Callbacks);
 }
 
 /*!

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -233,15 +233,9 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks) const
 */
 EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt, bool bCreateIfNull)
 {
-  auto it = std::find(ElementList.begin(), ElementList.end(), &PastElt);
-  if (it != ElementList.end()) {
-    it = std::find_if(it + 1, ElementList.end(), [&](auto &&element) {
-      return EbmlId(PastElt) == EbmlId(*element);
-    });
-
-    if (it != ElementList.end())
-      return *it;
-  }
+  EbmlElement *e = FindNextElt(PastElt);
+  if (e)
+    return e;
 
   if (bCreateIfNull) {
     // add the element

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -245,13 +245,7 @@ EbmlElement *EbmlMaster::FindNextElt(const EbmlElement & PastElt, bool bCreateIf
 
   if (bCreateIfNull) {
     // add the element
-    EbmlElement *NewElt = &(PastElt.CreateElement());
-
-    if (!PushElement(*NewElt)) {
-      delete NewElt;
-      NewElt = nullptr;
-    }
-    return NewElt;
+    return AddNewElt(PastElt.ElementSpec());
   }
 
   return nullptr;

--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -216,15 +216,7 @@ EbmlElement *EbmlMaster::FindFirstElt(const EbmlCallbacks & Callbacks, bool bCre
 
   if (bCreateIfNull) {
     // add the element
-    EbmlElement *NewElt = &EBML_INFO_CREATE(Callbacks);
-    if (NewElt == nullptr)
-      return nullptr;
-
-    if (!PushElement(*NewElt)) {
-      delete NewElt;
-      NewElt = nullptr;
-    }
-    return NewElt;
+    return AddNewElt(Callbacks);
   }
 
   return nullptr;

--- a/test/test_missing.cxx
+++ b/test/test_missing.cxx
@@ -31,7 +31,7 @@ static void FindAllMissingElements(const EbmlMaster *pThis, std::vector<std::str
   unsigned int EltIdx;
   for (EltIdx = 0; EltIdx < EBML_CTX_SIZE(MasterContext); EltIdx++) {
     if (EBML_CTX_IDX(MasterContext,EltIdx).IsMandatory()) {
-      if (pThis->FindElt(EBML_CTX_IDX_INFO(MasterContext,EltIdx)) == nullptr) {
+      if (pThis->FindFirstElt(EBML_CTX_IDX_INFO(MasterContext,EltIdx)) == nullptr) {
         std::string missingElement;
         missingElement = "Missing element \"";
         missingElement.append(EBML_INFO_NAME(EBML_CTX_IDX_INFO(MasterContext,EltIdx)));


### PR DESCRIPTION
FindElt() is a duplicate of FindFirstElt().

This will require https://github.com/Matroska-Org/libmatroska/pull/194 for libmatroska as it was using FindElt() (and vice versa for the extra const).