### PR TITLE
remove constexpr from DEFINE_xxx_CONTEXT()

### DIFF
--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -55,7 +55,7 @@ class EbmlSemanticContextMaster;
 class EbmlElement;
 
 #define DEFINE_xxx_CONTEXT(x,global) \
-    constexpr const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
+    const libebml::EbmlSemanticContextMaster Context_##x = libebml::EbmlSemanticContextMaster(countof(ContextList_##x), ContextList_##x, nullptr, global, nullptr); \
 
 #define DEFINE_xxx_MASTER(x,id,parent,infinite,name,versions,global) \
     DEFINE_xxx_MASTER_CONS(x,id,parent,infinite,name,versions,global) \

--- a/src/EbmlContexts.cpp
+++ b/src/EbmlContexts.cpp
@@ -16,7 +16,7 @@ DEFINE_SEMANTIC_ITEM(false, false, EbmlCrc32)
 DEFINE_SEMANTIC_ITEM(false, false, EbmlVoid)
 DEFINE_END_SEMANTIC(EbmlGlobal)
 
-static DEFINE_xxx_CONTEXT(EbmlGlobal, GetEbmlGlobal_Context)
+static constexpr DEFINE_xxx_CONTEXT(EbmlGlobal, GetEbmlGlobal_Context)
 
 const EbmlSemanticContextMaster & GetEbmlGlobal_Context()
 {


### PR DESCRIPTION
It prevents from using DLL export (in libmatroska). We can set it locally when needed.