### PR TITLE
fix compilation by including header in which std::find is defined

### DIFF
--- a/src/EbmlUnicodeString.cpp
+++ b/src/EbmlUnicodeString.cpp
@@ -12,6 +12,7 @@
 
 #include "lib/utf8-cpp/source/utf8/checked.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace libebml {


### PR DESCRIPTION
Compilation breaks when the `algorithm` header isn't included indirectly anymore. This happens with certain combinations of compiler/C++ library/C++ mode, e.g. clang++ 17/libstdc++ 14.1/C++20