### PR TITLE
restrict the ranges of valid EBML ID values

### DIFF
--- a/ebml/EbmlDummy.h
+++ b/ebml/EbmlDummy.h
@@ -28,9 +28,9 @@ class EBML_DLL_API EbmlDummy : public EbmlBinary {
     EbmlElement * Clone() const override { return new EbmlDummy(DummyId); }
 
     static EbmlElement & Create() { return *(new EbmlDummy()); }
-    static const EbmlCallbacks ClassInfos;
 
   private:
+    static const EbmlCallbacks ClassInfos;
     const EbmlId DummyId;
     static constexpr EbmlId DummyRawId{0xFF};
 };

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -333,9 +333,6 @@ class EBML_DLL_API EbmlDocVersion {
 };
 
 // functions for generic handling of data (should be static to all classes)
-/*!
-  \todo Handle default value
-*/
 class EBML_DLL_API EbmlCallbacks {
   public:
     using CreateOperator = EbmlElement & (*)(void);

--- a/ebml/EbmlId.h
+++ b/ebml/EbmlId.h
@@ -47,12 +47,12 @@ class EBML_DLL_API EbmlId {
     static constexpr bool IsValid(std::uint32_t Value)
     {
       if (Value < 0x100)
-        return Value >= 0x80;
+        return Value > 0x7F && Value < 0xFF;
       if (Value < 0x10000)
-        return Value >= 0x4000;
+        return Value > 0x407E && Value < 0x7FFF;
       if (Value < 0x1000000)
-        return Value >= 0x200000;
-      return Value >= 0x10000000;
+        return Value > 0x203FFE && Value < 0x3FFFFF;
+      return Value > 0x101FFFFE && Value < 0x1FFFFFFF;
     }
 
     static constexpr std::uint32_t FromBuffer(const binary aValue[4], const unsigned int aLength)

--- a/src/EbmlDummy.cpp
+++ b/src/EbmlDummy.cpp
@@ -12,7 +12,8 @@ namespace libebml {
 
 static constexpr EbmlDocVersion AllEbmlVersions{"ebml"};
 
-DEFINE_EBML_CLASS_ORPHAN(EbmlDummy, 0xFF, "DummyElement", AllEbmlVersions )
+static constexpr const EbmlSemanticContext Context_EbmlDummy = EbmlSemanticContext(nullptr, GetEbmlGlobal_Context, nullptr);
+constexpr const EbmlCallbacks EbmlDummy::ClassInfos(EbmlDummy::Create, EbmlDummy::DummyRawId, false, false, "DummyElement", Context_EbmlDummy, AllEbmlVersions);
 
 EbmlDummy::EbmlDummy(const EbmlId & aId) : EbmlBinary(EbmlDummy::ClassInfos), DummyId(aId) {}
 

--- a/test/test_macros.cxx
+++ b/test/test_macros.cxx
@@ -31,12 +31,12 @@ DEFINE_xxx_UNISTRING(UniStringWithoutDefault, 0x4123, EbmlHead, "UniStringWithou
 DECLARE_EBML_UINTEGER_DEF(UIntWithDefault)
     EBML_CONCRETE_CLASS(UIntWithDefault)
 };
-DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x654321, EbmlHead, "UIntWithDefault", 42, AllVersions)
+DEFINE_EBML_UINTEGER_DEF(UIntWithDefault, 0x354321, EbmlHead, "UIntWithDefault", 42, AllVersions)
 
 DECLARE_xxx_UINTEGER(UIntWithoutDefault,)
     EBML_CONCRETE_CLASS(UIntWithoutDefault)
 };
-DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x612345, EbmlHead, "UIntWithoutDefault", AllVersions, GetEbmlGlobal_Context)
+DEFINE_xxx_UINTEGER(UIntWithoutDefault, 0x312345, EbmlHead, "UIntWithoutDefault", AllVersions, GetEbmlGlobal_Context)
 
 int main(void)
 {


### PR DESCRIPTION
Match the exact values allowed in RFC 8794 Table 4 and 17.1 Ebml ID registry with errata https://www.rfc-editor.org/rfc/rfc8794.html#tableElementIDRanges https://www.rfc-editor.org/rfc/rfc8794.html#name-ebml-element-ids-registry

Not allowing the reserved values 0xFF, 0x7FFF, 0x3FFFFF and 0x1FFFFFFF. As they are reserved value maybe we should allow them in case they are used in the future ? But we don't know how.

`EbmlDummy` uses 0xFF internally which is supposed to be reserved. That ID value is never used but it's still an EbmlId object with a reserved/invalid value.

From the issue raised in https://github.com/Matroska-Org/libebml/commit/5326cfe8a2b81a05ade730ef9c53570d10f6d7ed#commitcomment-147015759