### PR TITLE
StdIOCallback: return 0 on read/write errors

### DIFF
--- a/src/StdIOCallback.cpp
+++ b/src/StdIOCallback.cpp
@@ -63,6 +63,8 @@ std::size_t StdIOCallback::read(void*Buffer,std::size_t Size)
   assert(File!=nullptr);
 
   const std::size_t result = fread(Buffer, 1, Size, File);
+  if (feof(File) || ferror(File))
+    return 0;
   mCurrentPosition += result;
   return result;
 }
@@ -99,6 +101,8 @@ std::size_t StdIOCallback::write(const void*Buffer,std::size_t Size)
 {
   assert(File!=nullptr);
   const size_t Result = fwrite(Buffer,1,Size,File);
+  if (feof(File) || ferror(File))
+    return 0;
   mCurrentPosition += Result;
   return Result;
 }


### PR DESCRIPTION
That's what the IOCallback abstraction expects.

VLC doesn't use this class, and likely not mkvtoolnix either. But the reference code should follow the spec.