### PR TITLE
[1.x] CMake: bump minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(ebml VERSION 1.4.5)
 


### PR DESCRIPTION
It fails to build in the CI because older versions support has been dropped in newer CMake.

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This is already done in the master branch.

(cherry picked from commit 6725c5f0169981cb0bd2ee124fbf0d8ca30b762d)