### PR TITLE
[1.x] CI: use actions/checkout@v4

### DIFF
--- a/.github/workflows/abibreak.yaml
+++ b/.github/workflows/abibreak.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get pushed code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure
         run: cmake -S . -B _build -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:STRING=${GITHUB_WORKSPACE}/_built -G Ninja
@@ -22,7 +22,7 @@ jobs:
         run: cmake --install _build --prefix ${GITHUB_WORKSPACE}/_built
 
       - name: Get v1.x code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libebml-1
           ref: v1.x

--- a/.github/workflows/linux-gcc13.yaml
+++ b/.github/workflows/linux-gcc13.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get pushed code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure CMake
         run: cmake -S . -B _build -DCMAKE_INSTALL_PREFIX:STRING=${GITHUB_WORKSPACE}/_built -G Ninja

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Get pushed code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure CMake
         run: cmake -S . -B _build -DCMAKE_INSTALL_PREFIX:STRING=${GITHUB_WORKSPACE}/_built -G Ninja

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Get pushed code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure CMake
         run: cmake -S . -B _build -DCMAKE_INSTALL_PREFIX:STRING=${GITHUB_WORKSPACE}/_built -G Ninja

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,7 +15,7 @@ jobs:
         config: [Debug, Release]
     steps:
       - name: Get pushed code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure CMake
         run: cmake -S . -B _build -DCMAKE_INSTALL_PREFIX:STRING=${GITHUB_WORKSPACE}/_built -G Ninja


### PR DESCRIPTION
v3 issues some warning of deprecated stuff.

(cherry picked from commit f7cc11237cb833fb6b28a9a071952e6d43063b73)