### PR TITLE
[1.x] EbmlMaster: fix leak when reading upper level elements

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -455,9 +455,12 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
 
       if (UpperEltFound > 0) {
         UpperEltFound--;
-        if (UpperEltFound > 0 || MaxSizeToRead <= 0)
+        if (UpperEltFound > 0)
           goto processCrc;
         ElementLevelA = FoundElt;
+        if (IsFiniteSize() && ElementLevelA->IsFiniteSize()) {
+          MaxSizeToRead = GetEndPosition() - ElementLevelA->GetEndPosition(); // even if it's the default value
+        }
         continue;
       }
 


### PR DESCRIPTION
When an element from an upper level is found we go up the caller chain, passing the found element but it was not actually used (added to a list or freed).

This patch allows setting that element as the ElementLevelA found in the loop. We skip the call the inDataStream.FindNextElement() to find it.

The new MaxSizeToRead is the size to read in the next inDataStream.FindNextElement() call.

The old MaxSizeToRead <= 0 code seems bogus as it would exit the loop to find elements for that EbmlMaster even though there might still be elements to read.