### PR TITLE
[1.x] IOCallback: avoid reading more than 2^32 at once

### DIFF
--- a/src/IOCallback.cpp
+++ b/src/IOCallback.cpp
@@ -33,6 +33,7 @@
   \author Moritz Bunkus <moritz @ bunkus.org>
 */
 
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -64,10 +65,17 @@ void IOCallback::readFully(void*Buffer,size_t Size)
   if(Buffer == nullptr)
     throw;
 
-  if(read(Buffer,Size) != Size) {
-    stringstream Msg;
-    Msg<<"EOF in readFully("<<Buffer<<","<<Size<<")";
-    throw runtime_error(Msg.str());
+  char *readBuf = static_cast<char *>(Buffer);
+  uint32_t readSize = static_cast<uint32_t>(std::min<size_t>(std::numeric_limits<uint32>::max(), Size));
+  while (readSize != 0) {
+    if(read(readBuf,readSize) != readSize) {
+      stringstream Msg;
+      Msg<<"EOF in readFully("<<Buffer<<","<<Size<<")";
+      throw runtime_error(Msg.str());
+    }
+    Size -= readSize;
+    readBuf += readSize;
+    readSize = static_cast<uint32_t>(std::min<size_t>(std::numeric_limits<uint32>::max(), Size));
   }
 }
 


### PR DESCRIPTION
In practice it should never happen as 2^32+1 buffers are not possible on any known platform. But better safe than sorry. Or memory mapped files could reach this code ?

(cherry picked from commit 40b4797829f6a35c1ea0a160ba7feed7443acb7d)