### PR TITLE
[1.x] EbmlHead: do not allow to have an infinite/unknown size

### DIFF
--- a/ebml/EbmlHead.h
+++ b/ebml/EbmlHead.h
@@ -46,6 +46,8 @@ DECLARE_EBML_MASTER(EbmlHead)
     EbmlHead(const EbmlHead & ElementToClone)  = default;
 
         EBML_CONCRETE_CLASS(EbmlHead)
+
+    bool SetSizeInfinite(bool finite = true) override { return !finite; }
 };
 
 } // namespace libebml


### PR DESCRIPTION
It does not have [^1]  unknownsizeallowed set to true (default to false)

[^1]: https://www.rfc-editor.org/rfc/rfc8794.html#section-11.2.1