### PR TITLE
Add missing includes

### DIFF
--- a/src/EbmlElement.cpp
+++ b/src/EbmlElement.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
+#include <new>
 
 #include "ebml/EbmlElement.h"
 #include "ebml/EbmlStream.h"


### PR DESCRIPTION
This file uses std::nothrow, which requires including `<new>`.

This fixes building with libc++ with _LIBCPP_REMOVE_TRANSITIVE_INCLUDES set (which removes unnecessary transitive dependencies, making it more strict wrt including all the right headers). This will become the default in a few versions, see [1].

This is only needed since commit 0d5873f3c0c4a4af376b8289ef7e240c6e72a8c7. Older versions before b5475c34e547989dff6c89c6af1050998d8a9067 require an extra include of <iterator> in src/EbmlMaster.cpp.

[1] https://discourse.llvm.org/t/rfc-remove-unused-transitive-includes-from-the-libc-headers/90157