### PR TITLE
[1.x] EbmlMaster: fix leak on upper element found inside the last element

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -445,8 +445,13 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
 
           if (UpperEltFound) {
             --UpperEltFound;
-            if (UpperEltFound > 0 || MaxSizeToRead <= 0)
+            if (UpperEltFound > 0)
               goto processCrc;
+            if (MaxSizeToRead <= 0) {
+              delete FoundElt;
+              FoundElt = nullptr;
+              goto processCrc;
+            }
             ElementLevelA = FoundElt;
           }
 
@@ -458,6 +463,11 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
         UpperEltFound--;
         if (UpperEltFound > 0)
           goto processCrc;
+        if (MaxSizeToRead <= 0) {
+          delete FoundElt;
+          FoundElt = nullptr;
+          goto processCrc;
+        }
         ElementLevelA = FoundElt;
         if (IsFiniteSize() && ElementLevelA->IsFiniteSize()) {
           MaxSizeToRead = GetEndPosition() - ElementLevelA->GetEndPosition(); // even if it's the default value


### PR DESCRIPTION
We found an upper element and there is not data to read after the current element within its parent. That upper element is misplaced and should be discarded.
The last element is truncated and doesn't contain the rest of its data.