### PR TITLE
[1.x] EbmlMaster: exit reading loop if upper element found ends after its parent

### DIFF
--- a/src/EbmlMaster.cpp
+++ b/src/EbmlMaster.cpp
@@ -470,6 +470,9 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
         }
         ElementLevelA = FoundElt;
         if (IsFiniteSize() && ElementLevelA->IsFiniteSize()) {
+          if (ElementLevelA->GetEndPosition() > GetEndPosition()) {
+            goto processCrc; // found an upper element that ends after this, we were truncated
+          }
           MaxSizeToRead = GetEndPosition() - ElementLevelA->GetEndPosition(); // even if it's the default value
         }
         continue;


### PR DESCRIPTION
It could be a file with missing data in the middle. And we shouldn't use a `MaxSizeToRead` that would be negative.