### PR TITLE
fix detecting & using utf8c++ 4.0.0 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ function(add_cxx_flag_if_supported)
   endforeach()
 endfunction()
 
-find_package(utf8cpp 3.2.0)
+find_package(utf8cpp)
 if(NOT utf8cpp_FOUND)
   include(FetchContent REQUIRED)
   FetchContent_Declare(
@@ -60,6 +60,11 @@ if(NOT utf8cpp_FOUND)
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(utf8cpp)
+endif()
+if(TARGET utf8cpp::utf8cpp)
+  set(libebml_utf8cpp_link_libraries utf8cpp::utf8cpp)
+else()
+  set(libebml_utf8cpp_link_libraries $<BUILD_INTERFACE:utf8cpp>)
 endif()
 
 if(DEV_MODE)
@@ -157,7 +162,7 @@ if(MSVC)
   target_compile_definitions(ebml PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-target_link_libraries(ebml PRIVATE $<BUILD_INTERFACE:utf8cpp>)
+target_link_libraries(ebml PRIVATE ${libebml_utf8cpp_link_libraries})
 
 include(GenerateExportHeader)
 generate_export_header(ebml EXPORT_MACRO_NAME EBML_DLL_API)


### PR DESCRIPTION
`find_package` with version constraint `3.2.0` does not consider 4.x.y to be compatible. Therefore also look for 4.x.y in a secondary `find_package` call.

The fallback for cloning from git if neither version is found via `cmake` remains in place.

Furthermore, linking against a distro-provided 4.x.y doesn't seem to work with the existing `target_link_libraries(ebml PRIVATE $<BUILD_INTERFACE:utf8cpp>)` & requires `PRIVATE
utf8cpp::utf8cpp`. However, that doesn't work with a git-cloned copy; that still requires `PRIVATE $<BUILD_INTERFACE:utf8cpp>`; so make that argument depend on the package detection, too.

fixes #344 ; see #345