### PR TITLE
fix detecting & using utf8c++ 4.0.0 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ function(add_cxx_flag_if_supported)
   endforeach()
 endfunction()
 
-find_package(utf8cpp 3.2.0)
+find_package(utf8cpp)
 if(NOT utf8cpp_FOUND)
   include(FetchContent REQUIRED)
   FetchContent_Declare(
@@ -60,6 +60,11 @@ if(NOT utf8cpp_FOUND)
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(utf8cpp)
+endif()
+if(TARGET utf8cpp::utf8cpp)
+  set(libebml_utf8cpp_link_libraries utf8cpp::utf8cpp)
+else()
+  set(libebml_utf8cpp_link_libraries $<BUILD_INTERFACE:utf8cpp>)
 endif()
 
 if(DEV_MODE)
@@ -138,7 +143,7 @@ if(WIN32)
   target_compile_definitions(ebml PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-target_link_libraries(ebml PRIVATE $<BUILD_INTERFACE:utf8cpp>)
+target_link_libraries(ebml PRIVATE ${libebml_utf8cpp_link_libraries})
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
   if(${CMAKE_CXX_BYTE_ORDER} STREQUAL "BIG_ENDIAN")

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
   parent projects via `add_subdirectory`.
 * Enabled building shared libraries via the usual CMake definition
   `BUILD_SHARES_LIBS` (default: off).
+* Fixed cmake rules for building with utf8cpp 4.x; fixes #344
 
 # Version 1.4.3 2022-09-30
 


### PR DESCRIPTION
`find_package` with version constraint `3.2.0` does not consider 4.x.y to be compatible. Therefore also look for 4.x.y in a secondary `find_package` call.

The fallback for cloning from git if neither version is found via `cmake` remains in place.

Furthermore, linking against a distro-packaged 4.x.y doesn't seem to work with the existing `target_link_libraries(ebml PRIVATE $<BUILD_INTERFACE:utf8cpp>)` & requires `PRIVATE
utf8cpp::utf8cpp`. However, that doesn't work with a git-cloned copy nor with distro-packaged 3.2.x as those still requires `PRIVATE $<BUILD_INTERFACE:utf8cpp>`.

Therefore make the argument depend on availability of the `utf8cpp::utf8cpp` target: it is available only for distro-packaged 4.x.y. For the other two cases (distro-packaged < 4.x.y & cloned from git) we stay with `$<BUILD_INTERFACE:utf8cpp>`.

fixes #344 for master