### PR TITLE
CMake: remove bogus BUILD_SHARED_LIBS dependent option

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,12 +7,17 @@ on:
 
 jobs:
   build_libebml:
-    name: libebml ${{ matrix.arch.name }} ${{ matrix.config }}
+    name: libebml ${{ matrix.arch.name }} ${{ matrix.config }} (${{ matrix.lib.name }})
     runs-on: ${{ matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:
         config: [Debug, Release]
+        lib: [
+          { "name": "static", "option": "-DBUILD_SHARED_LIBS=OFF"},
+          { "name": "shared", "option": "-DBUILD_SHARED_LIBS=ON"},
+          { "name": "auto",   "option": ""},
+        ]
         arch: [
           { "name": "x64",   "option": "x64",   "runner": "windows-latest"},
           { "name": "x86",   "option": "win32", "runner": "windows-latest"},
@@ -25,7 +30,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure library
-        run: cmake -S . -B _build ${{ env.CMAKE_OPTIONS }} -A ${{ matrix.arch.option }}
+        run: cmake -S . -B _build ${{ env.CMAKE_OPTIONS }} ${{ matrix.lib.option }} -A ${{ matrix.arch.option }}
 
       - name: Build
         run: cmake --build _build --config ${{ matrix.config }} --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(ebml VERSION 2.0.0)
 
-include(CMakeDependentOption)
-
 include( FeatureSummary )
 function(feature_info_on_off)
   set(option_name ${ARGV0})
@@ -14,7 +12,7 @@ function(feature_info_on_off)
   endif()
 endfunction(feature_info_on_off)
 
-cmake_dependent_option(BUILD_SHARED_LIBS "Build libebml as a shared library (except Windows)" OFF "NOT WIN32" OFF)
+option(BUILD_SHARED_LIBS "Build libebml as a shared library (except Windows)" OFF)
 feature_info_on_off(BUILD_SHARED_LIBS "will build as a dynamic library" "will build as a static library")
 
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)

--- a/ebml/EbmlElement.h
+++ b/ebml/EbmlElement.h
@@ -193,8 +193,8 @@ class DllApi x : public BaseClass { \
 
 #define DECLARE_xxx_MASTER(x,DllApi)    \
   DECLARE_xxx_BASE_MASTER(x, DllApi, libebml::EbmlMaster) \
-  static const libebml::EbmlSemanticContextMaster SemanticContext; \
-  static const libebml::EbmlSemanticContextMaster & GetContextMaster() { return SemanticContext; }
+  static const libebml::EbmlSemanticContextMaster DllApi SemanticContext; \
+  static const libebml::EbmlSemanticContextMaster DllApi & GetContextMaster() { return SemanticContext; }
 
 #define DECLARE_xxx_BINARY(x,DllApi)    \
   DECLARE_xxx_BASE(x, DllApi, libebml::EbmlBinary)


### PR DESCRIPTION
When forcing BUILD_SHARED_LIBS=ON on Windows it still defaults to OFF.
And it was always OFF by default regardless of the platform anyway.